### PR TITLE
Support `attachTo` option for mount rendering

### DIFF
--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -39,7 +39,10 @@ export default class Adapter extends EnzymeAdapter {
   createRenderer(options: AdapterOptions) {
     switch (options.mode) {
       case 'mount':
-        return new MountRenderer();
+        // The `attachTo` option is only supported for DOM rendering, for
+        // consistency with React, even though the Preact adapter could easily
+        // support it for shallow rendering.
+        return new MountRenderer({ container: options.attachTo });
       case 'shallow':
         return new ShallowRenderer();
       case 'string':

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -10,12 +10,20 @@ import { withReplacedMethod } from './util';
 
 type EventDetails = { [prop: string]: any };
 
+export interface Options {
+  /**
+   * The container element to render into.
+   * If not specified, a detached element (not connected to the body) is used.
+   */
+  container?: HTMLElement;
+}
+
 export default class MountRenderer implements EnzymeRenderer {
   private _container: HTMLElement;
   private _getNode: typeof getNodeClassic;
 
-  constructor() {
-    this._container = document.createElement('div');
+  constructor({ container }: Options = {}) {
+    this._container = container || document.createElement('div');
 
     if (isPreact10()) {
       this._getNode = getNodeV10;

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -15,6 +15,13 @@ describe('MountRenderer', () => {
       assert.instanceOf(renderer.getNode()!.instance, HTMLDivElement);
     });
 
+    it('renders the element into the provided container', () => {
+      const container = document.createElement('div');
+      const renderer = new MountRenderer({ container });
+      renderer.render(<button/>);
+      assert.ok(container.querySelector('button'));
+    });
+
     it('invokes the post-render callback', () => {
       const renderer = new MountRenderer();
       const callback = sinon.stub();

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -396,6 +396,13 @@ describe('integration tests', () => {
       const div = wrapper.get(0);
       assert.deepEqual(div.type, 'div');
     });
+
+    it('supports rendering into an existing container', () => {
+      const container = document.createElement('div');
+      const wrapper = mount(<button />, { attachTo: container });
+      assert.ok(container.querySelector('button'));
+      wrapper.detach();
+    });
   });
 
   describe('"shallow" rendering', () => {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -63,6 +63,9 @@ declare module 'enzyme' {
 
   export interface AdapterOptions {
     mode: 'mount' | 'shallow' | 'string';
+
+    /** DOM container to render into. */
+    attachTo?: HTMLElement;
   }
 
   /**


### PR DESCRIPTION
This enables rendering into an existing DOM container element.

See https://airbnb.io/enzyme/docs/api/mount.html#mountnode-options--reactwrapper