### PR TITLE
Flush effects after initial render

### DIFF
--- a/test/init.ts
+++ b/test/init.ts
@@ -3,12 +3,14 @@ import minimist from 'minimist';
 
 // Setup DOM globals required by Preact rendering.
 function setupJSDOM() {
-  const dom = new JSDOM();
+  // Enable `requestAnimationFrame` which Preact 10 uses for scheduling hooks.
+  const dom = new JSDOM('', { pretendToBeVisual: true });
   const g = global as any;
   g.Event = dom.window.Event;
   g.Node = dom.window.Node;
   g.window = dom.window;
   g.document = dom.window.document;
+  g.requestAnimationFrame = dom.window.requestAnimationFrame;
 }
 setupJSDOM();
 


### PR DESCRIPTION
Flush any effects scheduled with `useEffect` using the `act` helper
on the initial render.

This means that in a test a developer can write:

```js
const wrapper = mount(<ComponentThatUsesEffects/>)
```

And know that effects will have been run before they start interacting
with the result wrapper.

See https://github.com/airbnb/enzyme/pull/2034 for corresponding change
to the React adapter.