### PR TITLE
Flush state updates and effects after simulated events

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -124,7 +124,10 @@ export default class MountRenderer implements EnzymeRenderer {
       cancelable: args.cancelable,
     });
     Object.assign(event, args);
-    node.instance.dispatchEvent(event);
+
+    act(() => {
+      node.instance.dispatchEvent(event);
+    });
   }
 
   batchedUpdates(fn: () => {}) {

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -58,7 +58,7 @@ describe('MountRenderer', () => {
     });
 
     if (isPreact10()) {
-      const { useEffect, useLayoutEffect } = require('preact/hooks');
+      const { useEffect, useLayoutEffect, useState } = require('preact/hooks');
 
       it('executes effect hooks on initial render', () => {
         let effectCount = 0;
@@ -97,6 +97,30 @@ describe('MountRenderer', () => {
         assert.equal(effectRemoved, false);
         renderer.unmount();
         assert.equal(effectRemoved, true);
+      });
+
+      it('flushes hooks and state updates after a simulated event', () => {
+        let clicked = false;
+        let effectCount = 0;
+
+        function TestComponent() {
+          const [clicked_, setClicked] = useState(false);
+          useEffect(() => {
+            ++effectCount;
+            clicked = clicked_;
+          });
+          return <div onClick={() => setClicked(true)} />;
+        }
+
+        const renderer = new MountRenderer();
+        renderer.render(<TestComponent />);
+
+        effectCount = 0;
+        const divNode = renderer.getNode()!.rendered[0] as RSTNode;
+        renderer.simulateEvent(divNode, 'click');
+
+        assert.equal(effectCount, 1);
+        assert.equal(clicked, true);
       });
     }
   });


### PR DESCRIPTION
Discussions on the Enzyme repo suggest that `simulate(...)` is a
semi-deprecated API, but it is the obvious way to dispatch an event
according to the docs and still the most convenient way to do so.

Flushing state updates and effects after a simulated event dispatch
avoids confusion for users about why their component hasn't updated.