### PR TITLE
Upgrade Preact 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^6.0.2",
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@10.0.0-alpha.2",
+    "preact10": "npm:preact@10.0.0-beta.0",
     "prettier": "1.16.4",
     "sinon": "^7.2.3",
     "ts-node": "^8.0.2",
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "enzyme": "^3.8.0",
-    "preact": "^8.4.2 || ^10.0.0-alpha"
+    "preact": "^8.4.2 || ^10.0.0-beta"
   },
   "scripts": {
     "build": "tsc",

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -40,11 +40,18 @@ function convertDOMProps(props: Props) {
   return converted;
 }
 
-function rstNodesFromChildren(nodes: VNode[] | null): RSTNodeTypes[] {
+function rstNodesFromChildren(nodes: (VNode | null)[] | null): RSTNodeTypes[] {
   if (!nodes) {
     return [];
   }
   return flatMap(nodes, (node: VNode | null) => {
+    if (node === null) {
+      // The array of rendered children may have `null` entries as a result of
+      // eg. conditionally rendered children where the condition was false.
+      //
+      // These are omitted from the rendered tree that Enzyme works with.
+      return [];
+    }
     const rst = rstNodeFromVNode(node);
     return Array.isArray(rst) ? rst : [rst];
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,12 +1467,10 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@10.0.0-alpha.2":
-  version "10.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-alpha.2.tgz#61ba4f2ca20b75352ad5ed8aa239302df83dae74"
-  integrity sha512-8G0UFC0Sa/giqI/jR3LIHzj0ohsIC4wnB+8+XdpHFEZ5GmtFLmQgkrrkdR0EcEAdd38geClUSj30H8AEIO4OqA==
-  dependencies:
-    prop-types "^15.6.2"
+"preact10@npm:preact@10.0.0-beta.0":
+  version "10.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.0.tgz#8d53947b167449c09a678fefc2085c0f56ed34bd"
+  integrity sha512-BKd77y7ZpPLybjtM35DJtzXj+sxlAt29MCMGOJnSrsv1jt30aE/wS9qoU9nL8ih+yhal3B22mGAvuh2mGLAFMg==
 
 preact@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
The tests are currently failing because some DOM vnodes with no children have
a `_children` property equal to `[ null ]` (array with a single `null`
entry) rather than `null`. I need to work out whether this is
expected or a bug in Preact.