### PR TITLE
Fix exception when determining type of arrow function component

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "tsc",
     "format": "prettier --write src/**/*.{ts,tsx} test/**/*.{ts,tsx}",
     "prepublish": "rm -rf build && yarn run build",
-    "test": "mocha -r ts-node/register -r test/init.ts test/*.tsx",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"esnext\"}' mocha -r ts-node/register -r test/init.ts test/*.tsx",
     "test:compat": "yarn test --preact-compat-lib preact-compat",
     "test:preact10": "yarn test --preact-lib preact10",
     "test:preact10-compat": "yarn test --preact-lib preact10 --preact-compat-lib preact10/compat"

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -86,7 +86,7 @@ function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
 function nodeTypeFromType(type: any): NodeType {
   if (typeof type === 'string') {
     return 'host';
-  } else if (typeof type.prototype.render === 'function') {
+  } else if (type.prototype && typeof type.prototype.render === 'function') {
     return 'class';
   } else if (typeof type === 'function') {
     return 'function';

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -29,6 +29,8 @@ function FunctionComponent({ label }: any) {
   return <div>{label}</div>;
 }
 
+const ArrowFunctionComponent = ({ label }: any) => <div>{label}</div>;
+
 function NumberComponent({ value }: { value: number }) {
   return <div>{value}</div>;
 }
@@ -159,6 +161,15 @@ const treeCases = [
     element: <FunctionComponent label="Hello" />,
     expectedTree: functionNode({
       type: FunctionComponent,
+      rendered: [hostNode({ type: 'div', rendered: ['Hello'] })],
+      props: { label: 'Hello' },
+    }),
+  },
+  {
+    description: 'function component (arrow function)',
+    element: <ArrowFunctionComponent label="Hello" />,
+    expectedTree: functionNode({
+      type: ArrowFunctionComponent,
       rendered: [hostNode({ type: 'div', rendered: ['Hello'] })],
       props: { label: 'Hello' },
     }),


### PR DESCRIPTION
Fix an exception when determining the type of a component if the
component was declared with an arrow function. Native (untranspiled)
arrow functions do not have a `prototype` property.

The existing tests would have encountered the issue, except that they
used the same transpilation settings (to ES5) as for distribution.

Fixes #37