### PR TITLE
Update Preact 10 to 10.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^6.0.2",
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@^10.0.0-beta.1",
+    "preact10": "npm:preact@^10.0.0-beta.2",
     "prettier": "1.17.1",
     "sinon": "^7.2.3",
     "ts-node": "^8.0.2",

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -61,8 +61,18 @@ function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
   if (node == null) {
     return null;
   }
-  if (node.text !== null) {
+  if (node.text != null) {
+    // The `text` property was removed in Preact 10.0.0-beta 2
+    // (see https://github.com/preactjs/preact/pull/1600).
+    //
+    // If this change persists to the stable Preact 10 release then this branch
+    // can be removed.
     return String(node.text);
+  }
+  if (typeof node.props === 'string' || typeof node.props === 'number') {
+    // Preact 10.0.0-beta.2 represents text nodes as VNodes with
+    // `node.type == null` and `node.props` equal to the string content.
+    return String(node.props);
   }
 
   const component = getComponent(node);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@^10.0.0-beta.1":
-  version "10.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.1.tgz#f7d524668db72ed74e99d447f09600fa4db0b186"
-  integrity sha512-1uhj3JXOEzEPUof5t/iQW5heEvTOpexwS0FLAjJQfgfT8OCXICyzI2TwkYyFJ+W9q9GsDmhZgFagH2G0akFveQ==
+"preact10@npm:preact@^10.0.0-beta.2":
+  version "10.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.2.tgz#659b6520eb41d5a3d178a61b3311e6ae79d8cf56"
+  integrity sha512-sKu2tdECRcmG8B2Q0GIAhTR95PhaWy15RkYFgpzfkEQLo7qqnE5lYQO2ccHNTfwuzj0LVPRdG71s5QjhnRyVbQ==
 
 preact@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
The representation of text nodes changed from 10.0.0-beta.1 to 10.0.0-beta.2.

 - The `text` property ~~may not be missing entirely rather than just `null`~~ is missing entirely
 - Text nodes are now represented as vnodes with type `null` and `vnode.props` equal to the string or number value

This PR is backwards-compatible with earlier betas.

Fixes #48