### PR TITLE
Support Enzyme v3.10

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -1,4 +1,4 @@
-import { EnzymeRenderer, RSTNode } from 'enzyme';
+import { MountRenderer as AbstractMountRenderer, RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 
 import { getNode as getNodeClassic } from './preact8-rst';
@@ -34,7 +34,7 @@ function act(callback: () => any) {
   }
 }
 
-export default class MountRenderer implements EnzymeRenderer {
+export default class MountRenderer implements AbstractMountRenderer {
   private _container: HTMLElement;
   private _getNode: typeof getNodeClassic;
 

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -1,4 +1,8 @@
-import { EnzymeRenderer, RSTNode } from 'enzyme';
+import {
+  ShallowRenderer as AbstractShallowRenderer,
+  RSTNode,
+  ShallowRenderOptions,
+} from 'enzyme';
 import { VNode } from 'preact';
 
 import MountRenderer from './MountRenderer';
@@ -8,14 +12,14 @@ import {
 } from './shallow-render-utils';
 import { childElements } from './compat';
 
-export default class ShallowRenderer implements EnzymeRenderer {
+export default class ShallowRenderer implements AbstractShallowRenderer {
   private _mountRenderer: MountRenderer;
 
   constructor() {
     this._mountRenderer = new MountRenderer();
   }
 
-  render(el: VNode, context?: any, callback?: () => any) {
+  render(el: VNode, context?: any, options?: ShallowRenderOptions) {
     // Make all elements in the input tree, except for the root element, render
     // to a stub.
     childElements(el).forEach(el => {
@@ -26,7 +30,7 @@ export default class ShallowRenderer implements EnzymeRenderer {
 
     // Make any new elements rendered by the root element render to a stub.
     withShallowRendering(() => {
-      this._mountRenderer.render(el, context, callback);
+      this._mountRenderer.render(el, context);
 
       const rootNode = this._mountRenderer.getNode() as RSTNode;
       if (rootNode.type === 'host') {

--- a/src/StringRenderer.ts
+++ b/src/StringRenderer.ts
@@ -1,10 +1,10 @@
-import { EnzymeRenderer, JSXElement, RSTNode } from 'enzyme';
+import { Renderer, JSXElement, RSTNode } from 'enzyme';
 import { render as renderToString } from 'preact-render-to-string';
 import { h, render } from 'preact';
 
 import { isPreact10 } from './util';
 
-export default class StringRenderer implements EnzymeRenderer {
+export default class StringRenderer implements Renderer {
   render(el: JSXElement, context?: any) {
     if (isPreact10()) {
       // preact-render-to-string does not support Preact 10 yet.

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -38,9 +38,7 @@ declare module 'enzyme' {
   /**
    * A UI renderer created by an `EnzymeAdapter`
    */
-  export interface EnzymeRenderer {
-    render(el: JSXElement, context?: any, callback?: () => any): void;
-
+  export interface Renderer {
     /** Remove the rendered output from the DOM. */
     unmount(): void;
 
@@ -59,6 +57,41 @@ declare module 'enzyme' {
     simulateEvent(node: RSTNode, event: string, args: Object): void;
 
     batchedUpdates(fn: () => {}): void;
+  }
+
+  /**
+   * HTML renderer created by an adapter when `createRenderer` is called with
+   * `{ mode: "string" }`
+   */
+  export interface StringRenderer extends Renderer {
+    render(el: JSXElement, context?: any): void;
+  }
+
+  /**
+   * Full DOM renderer created by an adapter when `createRenderer` is called
+   * with `{ mode: "mount" }`
+   */
+  export interface MountRenderer extends Renderer {
+    render(el: JSXElement, context?: any, callback?: () => any): void;
+  }
+
+  /**
+   * Options passed to the `render` function of a shallow renderer.
+   */
+  export interface ShallowRenderOptions {
+    /**
+     * A map of context provider type, from the provider/consumer pair created
+     * by React's `createContext` API, to current value.
+     */
+    providerValues: Map<Object, any>;
+  }
+
+  /**
+   * Shallow renderer created by an adapter when `createRenderer` is called
+   * with `{ mode: "shallow" }`
+   */
+  export interface ShallowRenderer extends Renderer {
+    render(el: JSXElement, context?: any, options?: ShallowRenderOptions): void;
   }
 
   export interface AdapterOptions {
@@ -87,7 +120,7 @@ declare module 'enzyme' {
       props: Object,
       ...children: JSXElement[]
     ): JSXElement;
-    abstract createRenderer(options: AdapterOptions): EnzymeRenderer;
+    abstract createRenderer(options: AdapterOptions): Renderer;
     abstract elementToNode(element: JSXElement): RSTNode;
     abstract isValidElement(el: JSXElement): boolean;
     abstract nodeToElement(node: RSTNode): JSXElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*":
-  version "10.12.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.23.tgz#308a3acdc5d1c842aeadc50b867d99c46cfae868"
-  integrity sha512-EKhb5NveQ3NlW5EV7B0VRtDKwUfVey8LuJRl9pp5iW0se87/ZqLjG0PMf2MCzPXAJYWZN5Ltg7pHIAf9/Dm1tQ==
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
+  integrity sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==
 
 "@types/sinon@^7.0.5":
   version "7.0.11"
@@ -294,12 +294,12 @@ check-error@^1.0.2:
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
-  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
   dependencies:
     css-select "~1.2.0"
-    dom-serializer "~0.1.0"
+    dom-serializer "~0.1.1"
     entities "~1.1.1"
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
@@ -339,9 +339,9 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
     delayed-stream "~1.0.0"
 
 commander@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -375,9 +375,9 @@ css-select@~1.2.0:
     nth-check "~1.0.1"
 
 css-what@2.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
-  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
 cssom@0.3.x, cssom@^0.3.4:
   version "0.3.6"
@@ -453,23 +453,18 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
+dom-serializer@0, dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
   dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
 
-domelementtype@1, domelementtype@^1.3.0:
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-  integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -527,9 +522,9 @@ entities@^1.1.1, entities@~1.1.1:
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 enzyme@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.9.0.tgz#2b491f06ca966eb56b6510068c7894a7e0be3909"
-  integrity sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.10.0.tgz#7218e347c4a7746e133f8e964aada4a3523452f6"
+  integrity sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==
   dependencies:
     array.prototype.flat "^1.2.1"
     cheerio "^1.0.0-rc.2"
@@ -797,16 +792,16 @@ html-encoding-sniffer@^1.0.2:
     whatwg-encoding "^1.0.1"
 
 htmlparser2@^3.9.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
-  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
   dependencies:
-    domelementtype "^1.3.0"
+    domelementtype "^1.3.1"
     domhandler "^2.3.0"
     domutils "^1.5.1"
     entities "^1.1.1"
     inherits "^2.0.1"
-    readable-stream "^3.0.6"
+    readable-stream "^3.1.1"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -1279,9 +1274,9 @@ object-is@^1.0.1:
   integrity sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
 
 object-keys@^1.0.11, object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object.assign@4.1.0, object.assign@^4.1.0:
   version "4.1.0"
@@ -1554,10 +1549,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-readable-stream@^3.0.6:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
-  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+readable-stream@^3.1.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -1650,12 +1645,7 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^1.3.1"
 
-semver@^5.4.1:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@^5.5.0:
+semver@^5.4.1, semver@^5.5.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==


### PR DESCRIPTION
An incorrect implementation of the shallow rendering APIs caused this adapter not to work with Enzyme 3.10. See first commit message for details.