### PR TITLE
Add support for VNode tree changes coming in next Preact 10 release

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -82,7 +82,14 @@ function findVNodeForDOM(vnode: VNode, el: Node): VNode | null {
   // Test the rendered output of this vnode.
   const component = getComponent(vnode);
   if (component) {
-    return findVNodeForDOM(getLastRenderOutput(component), el);
+    const rendered = getLastRenderOutput(component);
+    for (let v of rendered) {
+      const match = findVNodeForDOM(v, el);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
   }
 
   return null;
@@ -130,6 +137,9 @@ export function render(el: VNode, container: HTMLElement) {
  */
 export function childElements(el: VNode): (VNode | string | null)[] {
   if (isPreact10()) {
+    if (typeof el.props !== 'object' || el.props == null) {
+      return [];
+    }
     if (typeof el.props.children !== 'undefined') {
       return toArray(el.props.children);
     }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -3,13 +3,12 @@
  * Preact.
  */
 
-import { Component, VNode, h, render as preactRender } from 'preact';
+import { Component, Fragment, VNode, h, render as preactRender } from 'preact';
 
 import {
   getDOMNode,
   getComponent,
   getChildren,
-  getLastRenderOutput,
   getLastVNodeRenderedIntoContainer,
 } from './preact10-internals';
 
@@ -59,9 +58,12 @@ export function addTypeAndPropsToVNode() {
 /**
  * Search a tree of Preact v10 VNodes for the one that produced a given DOM element.
  */
-function findVNodeForDOM(vnode: VNode, el: Node): VNode | null {
-  // Test the current vnode itself.
-  if (getDOMNode(vnode) === el) {
+function findVNodeForDOM(
+  vnode: VNode,
+  el: Node,
+  filter: (v: VNode) => boolean
+): VNode | null {
+  if (getDOMNode(vnode) === el && filter(vnode)) {
     return vnode;
   }
 
@@ -72,31 +74,18 @@ function findVNodeForDOM(vnode: VNode, el: Node): VNode | null {
       if (typeof child === 'string') {
         continue;
       }
-      const match = findVNodeForDOM(child, el);
+      const match = findVNodeForDOM(child, el, filter);
       if (match) {
         return match;
       }
     }
-  }
-
-  // Test the rendered output of this vnode.
-  const component = getComponent(vnode);
-  if (component) {
-    const rendered = getLastRenderOutput(component);
-    for (let v of rendered) {
-      const match = findVNodeForDOM(v, el);
-      if (match) {
-        return match;
-      }
-    }
-    return null;
   }
 
   return null;
 }
 
 /**
- * Find the `Component` instance associated with a rendered DOM element.
+ * Find the `Component` instance that produced a given DOM node.
  */
 export function componentForDOMNode(el: Node): Component | null {
   // In Preact <= 8 this is easy, as rendered nodes have `_component` expando
@@ -105,21 +94,23 @@ export function componentForDOMNode(el: Node): Component | null {
     return componentForNode(el);
   }
 
-  // In Preact 10 we have to search up the tree until we find the root element
-  // which has a `_prevVNode` expando property, and then traverse the tree of
-  // VNodes until we find one with a matching `_dom` property.
-  const targetEl = el;
+  // In Preact 10 we have to search up the tree until we find the container
+  // that the root vnode was rendered into, then traverse the vnode tree to
+  // find the component vnode that produced the DOM element.
   let parentEl = el.parentNode;
-  while (parentEl) {
-    const rendered = getLastVNodeRenderedIntoContainer(parentEl);
-    if (rendered) {
-      const vnode = findVNodeForDOM(rendered, targetEl);
-      if (vnode) {
-        return getComponent(vnode);
-      }
-    }
+  let rootVNode = null;
+  while (parentEl && !rootVNode) {
+    rootVNode = getLastVNodeRenderedIntoContainer(parentEl);
     parentEl = parentEl.parentNode;
   }
+
+  if (rootVNode) {
+    const vnode = findVNodeForDOM(rootVNode, el, v => v.type !== Fragment);
+    if (vnode) {
+      return getComponent(vnode);
+    }
+  }
+
   return null;
 }
 

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -78,6 +78,10 @@ export function getLastRenderOutput(component: Component) {
 
 /**
  * Return the rendered DOM node associated with a rendered VNode.
+ *
+ * "Associated" here means either the DOM node directly output as a result of
+ * rendering the vnode (for DOM vnodes) or the first DOM node output by a
+ * child vnode for component vnodes.
  */
 export function getDOMNode(node: VNode): Node | null {
   return (node as PreactVNode).__e;

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -14,7 +14,11 @@ import { Component, VNode } from 'preact';
  * rendering.
  */
 interface PreactComponent extends Component {
+  // Original name: `_vnode`.
+  __v: VNode;
+
   // Original name: `_prevVNode`.
+  // Only present in Preact <= 10.0.0.beta.2.
   __t: VNode;
 }
 
@@ -22,8 +26,12 @@ interface PreactComponent extends Component {
  * A DOM element or text node created by Preact as a result of rendering.
  */
 interface PreactNode extends ChildNode {
+  // Original name: `_children`.
+  __k: PreactVNode;
+
   // Original name: `_prevVNode`.
-  __t: PreactVNode;
+  // Only present in Preact <= 10.0.0.beta.2, replaced by `_children`.
+  __t: VNode;
 }
 
 interface PreactVNode extends VNode {
@@ -42,14 +50,30 @@ interface PreactVNode extends VNode {
  * `render` function.
  */
 export function getLastVNodeRenderedIntoContainer(container: Node) {
-  return (container as PreactNode).__t;
+  const preactContainer = container as PreactNode;
+
+  // Preact 10 Beta 2 and earlier.
+  if (preactContainer.__t) {
+    return preactContainer.__t;
+  }
+
+  // Preact 10 Beta 3 and later.
+  return preactContainer.__k;
 }
 
 /**
  * Return the VNode returned when `component` was last rendered.
  */
 export function getLastRenderOutput(component: Component) {
-  return (component as PreactComponent).__t;
+  const preactComponent = component as PreactComponent;
+
+  // Preact 10 Beta 2 and earlier.
+  if (preactComponent.__t) {
+    return [preactComponent.__t];
+  }
+
+  // Preact 10 Beta 3 and later.
+  return getChildren(preactComponent.__v);
 }
 
 /**
@@ -70,5 +94,5 @@ export function getComponent(node: VNode): Component | null {
  * Return the child VNodes associated with a rendered VNode.
  */
 export function getChildren(node: VNode) {
-  return (node as PreactVNode).__k;
+  return (node as PreactVNode).__k!;
 }

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -109,7 +109,7 @@ describe('shallow-render-utils', () => {
       if (isPreact10()) {
         const fragVNode = getLastVNodeRenderedIntoContainer(container);
         const rootComponent = getComponent(getChildren(fragVNode)![0])!;
-        const rootOutput = getLastRenderOutput(rootComponent);
+        const rootOutput = getLastRenderOutput(rootComponent)[0];
         childComponent = getComponent(getChildren(rootOutput)![1])!;
       } else {
         const child = container.querySelector('shallow-render')!;


### PR DESCRIPTION
https://github.com/preactjs/preact/pull/1658 made some changes to the vnode/component tree for the next release. This PR makes the tests run against a current build of Preact 10 from master as well as the already-released beta 2.

When Preact 10 becomes the stable release, we can drop any code paths that are specific to earlier betas.

See the first commit message for more details.

**TODO**

- [x] Fix the regression in one test case with Preact 8