### PR TITLE
Defer pending updates until Enzyme wrapper is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
     "preact10": "npm:preact@^10.0.0-beta.2",
-    "prettier": "1.18.0",
+    "prettier": "1.18.2",
     "sinon": "^7.2.3",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.3"

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -23,6 +23,8 @@ export interface Options {
 
 let testUtils: any;
 if (isPreact10()) {
+  // nb. We require the whole module here rather than just getting a reference
+  // to the `act` function because `act` is patched in `debounce-render-hook`.
   testUtils = require('preact/test-utils');
 }
 

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -37,15 +37,15 @@ export default class ShallowRenderer implements AbstractShallowRenderer {
         return;
       }
 
-      // Monkey-patch the component's `setState` to make it shallow-render and
-      // force an update after rendering.
+      // Monkey-patch the component's `render` to make it shallow-render.
       const instance = rootNode.instance;
-      const originalSetState = instance.setState;
-      instance.setState = function(...args: any[]) {
+      const originalRender = instance.render;
+      instance.render = function(...args: any[]) {
+        let result;
         withShallowRendering(() => {
-          originalSetState.call(this, ...args);
+          result = originalRender.call(this, ...args);
         });
-        this.forceUpdate();
+        return result;
       };
 
       // Monkey-patch `componentDidMount` to prevent it being called a second

--- a/src/debounce-render-hook.ts
+++ b/src/debounce-render-hook.ts
@@ -1,0 +1,58 @@
+import { options } from 'preact';
+
+import { isPreact10 } from './util';
+
+let hookInstalled = false;
+const pendingCallbacks = new Set();
+
+/**
+ * Default implementation of debounced rendering, taken from Preact's
+ * `enqueueRender` implementation.
+ */
+function defer(callback: () => any) {
+  Promise.resolve().then(callback);
+}
+
+/**
+ * Install an `options.debounceRendering` hook that tracks any debounced
+ * renders scheduled by Preact, eg. due to a `setState` call.
+ *
+ * Scheduled renders will automatically flush in the next microtask as normal,
+ * but can be manually flushed using `flushRenders`.
+ */
+export function installHook() {
+  if (hookInstalled) {
+    return;
+  }
+
+  if (isPreact10()) {
+    // Install a workaround for https://github.com/preactjs/preact/issues/1681.
+    // This is only required for 10.0.0.beta.2 and earlier.
+    const testUtils = require('preact/test-utils');
+    const origAct = testUtils.act;
+    testUtils.act = (callback: () => any) => {
+      const prevHook = options.debounceRendering;
+      origAct(callback);
+      options.debounceRendering = prevHook;
+    };
+  }
+
+  const origDebounce = options.debounceRendering || defer;
+  function trackPendingRender(callback: () => any) {
+    pendingCallbacks.add(callback);
+    origDebounce.call(null, callback);
+  }
+  options.debounceRendering = trackPendingRender;
+  hookInstalled = true;
+}
+
+/**
+ * Synchronously perform any debounced renders that were scheduled by Preact
+ * using `options.debounceRendering`.
+ */
+export function flushRenders() {
+  pendingCallbacks.forEach(cb => {
+    cb();
+  });
+  pendingCallbacks.clear();
+}

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -11,7 +11,11 @@ function isNotPreact8Compat() {
   return isPreact10() || !isCompat;
 }
 
-function itIf(cond: () => boolean, description: string, fn: () => any) {
+function itIf(
+  cond: () => boolean,
+  description: string,
+  fn: (done?: () => any) => any
+) {
   const itFn = cond() ? it : it.skip;
   itFn(description, fn);
 }
@@ -324,7 +328,7 @@ function addInteractiveTests(render: typeof mount) {
     );
   });
 
-  itIf(isPreact10, 'supports simulating errors', () => {
+  itIf(isPreact10, 'supports simulating errors', done => {
     // let lastError = null;
 
     function Child() {
@@ -371,8 +375,11 @@ function addInteractiveTests(render: typeof mount) {
     // assert.equal(lastError, err);
 
     // Reset the error and render again, we should see the original content.
-    wrapper.setState({ error: null });
-    assert.equal(wrapper.text(), expectedText);
+    wrapper.setState({ error: null }, () => {
+      wrapper.update();
+      assert.equal(wrapper.text(), expectedText);
+      done!();
+    });
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.0.tgz#d1701ca9b2941864b52f3262b35946d2c9cd88f0"
-  integrity sha512-YsdAD29M0+WY2xXZk3i0PA16olY9qZss+AuODxglXcJ+2ZBwFv+6k5tE8GS8/HKAthaajlS/WqhdgcjumOrPlg==
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^3.5.1, pretty-format@^3.8.0:
   version "3.8.0"


### PR DESCRIPTION
In the browser, calls to `setState` within a single turn of the event loop are by default batched by Preact and scheduled to be applied using a method equivalent to [queueMicrotask](https://www.chromestatus.com/feature/5111086432911360). React v16 on the other hand batches `setState` calls [within an event handler](https://reactjs.org/docs/faq-state.html#when-is-setstate-asynchronous) and executes them immediately otherwise. React is planning on batching by default [in future](https://stackoverflow.com/questions/48563650/does-react-keep-the-order-for-state-updates/48610973#48610973) as well.

The Enzyme adapter used to change Preact's behavior to make it consistent with React. This had several issues:
- When using hooks together with [the recommended pattern for updating state in response to props changes](https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops), this could cause incorrect output (see https://github.com/preactjs/enzyme-adapter-preact-pure/issues/56).
- It creates a way in which a component in a test can behave differently from how it does normally

This PR resolves the issue by removing the change to `setState` behaviour but instead tracking whether any updates have been scheduled, and flushing them when the Enzyme tree is updated - either automatically be Enzyme or when `wrapper.update()` is called.

In most cases the update will be triggered via an Enzyme API call, or the call to `wrapper.update()` will already have been required. As a result, most tests should be unaffected.

Fixes https://github.com/preactjs/enzyme-adapter-preact-pure/issues/56
