### PR TITLE
Upgrade Preact 10 to 10.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nyc": "^14.1.1",
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@^10.0.0-beta.2",
+    "preact10": "npm:preact@^10.0.0-beta.3",
     "prettier": "1.18.2",
     "sinon": "^7.2.3",
     "source-map-support": "^0.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,10 +1929,10 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@^10.0.0-beta.2":
-  version "10.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.2.tgz#659b6520eb41d5a3d178a61b3311e6ae79d8cf56"
-  integrity sha512-sKu2tdECRcmG8B2Q0GIAhTR95PhaWy15RkYFgpzfkEQLo7qqnE5lYQO2ccHNTfwuzj0LVPRdG71s5QjhnRyVbQ==
+"preact10@npm:preact@^10.0.0-beta.3":
+  version "10.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.3.tgz#dabd0628d941f9e7908f68bb008e012ddff1b28f"
+  integrity sha512-JDeA+CVFBlv+r+v/tScG8hzOcOedXfBLUA5IhStqpfc7rPGY3T85pdlu4aGo2tV0AoZzQfO4LTnKkQEnKJ3UxQ==
 
 preact@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
The work to support the vnode tree changes in this release were already done in https://github.com/preactjs/enzyme-adapter-preact-pure/pull/55.