### PR TITLE
Upgrade Preact 10 to latest RC and remove workaround for beta releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nyc": "^14.1.1",
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@^10.0.0-beta.3",
+    "preact10": "npm:preact@^10.0.0-rc.1",
     "prettier": "1.18.2",
     "sinon": "^7.2.3",
     "source-map-support": "^0.5.12",

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -47,14 +47,14 @@ export function addTypeAndPropsToVNode() {
     set(val) {
       this.nodeName = val;
     },
-    
+
     configurable: true,
   });
   Object.defineProperty(VNode.prototype, 'props', {
     get() {
       return this.attributes || {};
     },
-    
+
     configurable: true,
   });
 }

--- a/src/debounce-render-hook.ts
+++ b/src/debounce-render-hook.ts
@@ -1,7 +1,5 @@
 import { options } from 'preact';
 
-import { isPreact10 } from './util';
-
 let hookInstalled = false;
 const pendingCallbacks = new Set();
 
@@ -23,18 +21,6 @@ function defer(callback: () => any) {
 export function installHook() {
   if (hookInstalled) {
     return;
-  }
-
-  if (isPreact10()) {
-    // Install a workaround for https://github.com/preactjs/preact/issues/1681.
-    // This is only required for 10.0.0.beta.2 and earlier.
-    const testUtils = require('preact/test-utils');
-    const origAct = testUtils.act;
-    testUtils.act = (callback: () => any) => {
-      const prevHook = options.debounceRendering;
-      origAct(callback);
-      options.debounceRendering = prevHook;
-    };
   }
 
   const origDebounce = options.debounceRendering || defer;

--- a/src/preact8-internals.ts
+++ b/src/preact8-internals.ts
@@ -8,6 +8,7 @@ import { Component } from 'preact';
  * ones (they are "mangled") during the build.
  */
 
+// @ts-ignore - Ignore error about `__k` and `__r` being private in `Component`
 interface Preact8Component extends Component {
   __k: string | null;
   __r: Function | null;
@@ -29,9 +30,9 @@ export function propsForNode(node: Node) {
 }
 
 export function componentKey(component: Component) {
-  return (component as Preact8Component).__k;
+  return ((component as unknown) as Preact8Component).__k;
 }
 
 export function componentRef(component: Component) {
-  return (component as Preact8Component).__r;
+  return ((component as unknown) as Preact8Component).__r;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,15 +1900,21 @@ pn@^1.1.0:
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
 preact-compat@^3.18.4:
-  version "3.18.4"
-  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.4.tgz#fbe76ddd30356c68e3ccde608107104946f2cf8d"
-  integrity sha512-aR5CvCIDerE2Y201ERVkWQdTAQKhKGNYujEk4tbyfQDInFTrnCCa3KCeGtULZrwy0PNRBjdQa2/Za7qv7ALNFg==
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.19.0.tgz#a71457b6a3bf051690a4411603bc2085aa061c2f"
+  integrity sha512-f83A4hIhH8Uzhb9GbIcGk8SM19ffWlwP9mDaYwQdRnMdekZwcCA7eIAbeV4EMQaV9C0Yuy8iKgBAtyTKPZQt/Q==
   dependencies:
     immutability-helper "^2.7.1"
+    preact-context "^1.1.3"
     preact-render-to-string "^3.8.2"
     preact-transition-group "^1.1.1"
     prop-types "^15.6.2"
     standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-context@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/preact-context/-/preact-context-1.1.3.tgz#26d06db0f39d8d9c890df5ada9a99a943586ec68"
+  integrity sha512-2LcpjZG6JUhBgqziVH+nJtmu9PS5KzWoFx6wX2svXw0oBHhU6e8tQZhEkKLMOAxdmj7gVzApfS/B6V+fjJ/llA==
 
 preact-render-to-string@^3.8.2:
   version "3.8.2"
@@ -1935,9 +1941,9 @@ preact-transition-group@^1.1.1:
   integrity sha512-DyG8ySCbrQZ8w4cSyxnofM6yH/hzyYLHmIrE3xL1FjSCX4DpvVmP7DTpkV535FSQX0d2zOscb7DCIY+crBtxow==
 
 preact@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
-  integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.0.tgz#05690de3af035cd8ad393e8b4057b8ab29aedee1"
+  integrity sha512-S2OOz+lRjfbqDbV5LOIcJ6yfYvshDtKvvsMwaFW84wuw4HtFUYH67T+hnWhdCDYtW8BfmyIg9utz16s6U80HbA==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2017,9 +2023,9 @@ randexp@0.4.6:
     ret "~0.1.10"
 
 react-is@^16.8.1:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
-  integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 read-pkg-up@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,10 +1929,10 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@^10.0.0-beta.3":
-  version "10.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.3.tgz#dabd0628d941f9e7908f68bb008e012ddff1b28f"
-  integrity sha512-JDeA+CVFBlv+r+v/tScG8hzOcOedXfBLUA5IhStqpfc7rPGY3T85pdlu4aGo2tV0AoZzQfO4LTnKkQEnKJ3UxQ==
+"preact10@npm:preact@^10.0.0-rc.1":
+  version "10.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-rc.1.tgz#bae4419f8e289c327504d4ee6e734c377983548c"
+  integrity sha512-DyG8ySCbrQZ8w4cSyxnofM6yH/hzyYLHmIrE3xL1FjSCX4DpvVmP7DTpkV535FSQX0d2zOscb7DCIY+crBtxow==
 
 preact@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
The workaround caused problems in environments where mutating package
exports is prevented. See https://github.com/preactjs/enzyme-adapter-preact-pure/issues/68

I've also upgraded Preact v8 to the latest v8.x release.

Fixes #68