### PR TITLE
Update to Preact 10.0.0 and fix `wrapper.simulateError`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nyc": "^14.1.1",
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@^10.0.0-rc.3",
+    "preact10": "npm:preact@^10.0.0",
     "prettier": "1.18.2",
     "sinon": "^7.2.3",
     "source-map-support": "^0.5.12",

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -100,7 +100,9 @@ export default class MountRenderer implements AbstractMountRenderer {
     };
 
     withReplacedMethod(errNode.instance, 'render', render, () => {
-      errNode.instance.forceUpdate();
+      act(() => {
+        errNode.instance.forceUpdate();
+      });
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,10 +1966,10 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@^10.0.0-rc.3":
-  version "10.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-rc.3.tgz#258d1bbf11744e0460b8681422cd6a0c18200df7"
-  integrity sha512-IvDc2AGvHJncEtORciLDzpluDF2MsZqf9eo6xHt7HVY4E6OvxZzAePYJtv3siVdEntxmB9NciQpbToT1APqJYQ==
+"preact10@npm:preact@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0.tgz#c528f04ac6c792a04d8c98a5144d8b13e0cf2aed"
+  integrity sha512-v5geBMq8xlX7Ai8ed0QFXIs7/SQ+4lzdu3fpApRspZ6IiFDRHeEXQ3fqns0jDsXseHjYqgWlK1QxqdWF4QrdFw==
 
 preact@^8.4.2:
   version "8.5.1"


### PR DESCRIPTION
`forceUpdate` is asynchronous in Preact 10.0.0, in the same way as
`setState`. Therefore we need to wrap it in an `act` call to trigger it
synchronously.