### PR TITLE
Make Preact 10 the default version in the code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: node_js
 node_js:
   - "node"
 script:
-  # Preact 8.x.
-  - yarn test
-  # Preact 8.x with preact-compat
-  - yarn test:compat
   # Preact 10.
-  - yarn test:preact10
+  - yarn test
   # Preact 10 with preact/compat
-  - yarn test:preact10-compat
+  - yarn test:compat
+  # Preact 8.x.
+  - yarn test:preact8
+  # Preact 8.x with preact-compat
+  - yarn test:preact8-compat
   # Example projects
   - examples/run-all.sh

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "minimist": "^1.2.0",
     "mocha": "^6.0.2",
     "nyc": "^14.1.1",
-    "preact": "^8.4.2",
+    "preact": "^10.0.0",
     "preact-compat": "^3.18.4",
-    "preact10": "npm:preact@^10.0.0",
+    "preact8": "npm:preact@^8.4.2",
     "prettier": "1.18.2",
     "sinon": "^7.2.3",
     "source-map-support": "^0.5.12",
@@ -30,16 +30,16 @@
   },
   "peerDependencies": {
     "enzyme": "^3.8.0",
-    "preact": "^8.4.2 || ^10.0.0-beta"
+    "preact": "^8.4.2 || ^10.0.0"
   },
   "scripts": {
     "build": "tsc",
     "format": "prettier --write src/**/*.{ts,tsx} test/**/*.{ts,tsx}",
     "prepublish": "rm -rf build && yarn run build",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"esnext\"}' nyc mocha -r ts-node/register/transpile-only -r source-map-support/register -r test/init.ts test/*.tsx",
-    "test:compat": "yarn test --preact-compat-lib preact-compat",
-    "test:preact10": "yarn test --preact-lib preact10",
-    "test:preact10-compat": "yarn test --preact-lib preact10 --preact-compat-lib preact10/compat"
+    "test:compat": "yarn test --preact-compat-lib preact/compat",
+    "test:preact8": "yarn test --preact-lib preact8",
+    "test:preact8-compat": "yarn test --preact-lib preact8 --preact-compat-lib preact-compat"
   },
   "dependencies": {
     "array.prototype.flatmap": "^1.2.1",

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -11,7 +11,9 @@ import MountRenderer from './MountRenderer';
 import ShallowRenderer from './ShallowRenderer';
 import StringRenderer from './StringRenderer';
 import { addTypeAndPropsToVNode } from './compat';
-import { rstNodeFromElement } from './preact10-rst';
+import { isPreact10 } from './util';
+import { rstNodeFromElement as rstNodeFromElementV10 } from './preact10-rst';
+import { rstNodeFromElement as rstNodeFromElementV8 } from './preact8-rst';
 
 export default class Adapter extends EnzymeAdapter {
   constructor() {
@@ -99,6 +101,9 @@ export default class Adapter extends EnzymeAdapter {
   }
 
   elementToNode(el: JSXElement): RSTNode {
+    const rstNodeFromElement = isPreact10()
+      ? rstNodeFromElementV10
+      : rstNodeFromElementV8;
     return rstNodeFromElement(el as VNode) as RSTNode;
   }
 }

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -1,7 +1,7 @@
 import { MountRenderer as AbstractMountRenderer, RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 
-import { getNode as getNodeClassic } from './preact8-rst';
+import { getNode as getNodeV8 } from './preact8-rst';
 import { getNode as getNodeV10 } from './preact10-rst';
 import { getDisplayName, isPreact10, withReplacedMethod } from './util';
 import { render } from './compat';
@@ -42,7 +42,7 @@ function act(callback: () => any) {
 
 export default class MountRenderer implements AbstractMountRenderer {
   private _container: HTMLElement;
-  private _getNode: typeof getNodeClassic;
+  private _getNode: typeof getNodeV10;
 
   constructor({ container }: Options = {}) {
     installDebounceHook();
@@ -52,7 +52,7 @@ export default class MountRenderer implements AbstractMountRenderer {
     if (isPreact10()) {
       this._getNode = getNodeV10;
     } else {
-      this._getNode = getNodeClassic;
+      this._getNode = getNodeV8;
     }
   }
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -92,9 +92,9 @@ function findVNodeForDOM(
  * Find the `Component` instance that produced a given DOM node.
  */
 export function componentForDOMNode(el: Node): Component | null {
-  // In Preact <= 8 this is easy, as rendered nodes have `_component` expando
+  // In Preact 8 this is easy, as rendered nodes have `_component` expando
   // property.
-  if ('_component' in el) {
+  if (!isPreact10()) {
     return componentForNode(el);
   }
 

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -119,11 +119,6 @@ function nodeTypeFromType(type: any): NodeType {
 /**
  * Convert a JSX element tree returned by Preact's `h` function into an RST
  * node.
- *
- * This function accepts vnodes produced by both Preact 10 and earlier versions.
- * Since the elements have not been rendered, none of the private properties
- * which store references to the associated DOM element, component instance etc.
- * will have been set.
  */
 export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
   if (node == null || typeof node === 'string') {
@@ -140,7 +135,7 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
         : stripSpecialProps(node.props);
   }
 
-  const ref = node.ref /* Preact 10 */ || null;
+  const ref = node.ref || null;
 
   return {
     nodeType,

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -140,7 +140,7 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
         : stripSpecialProps(node.props);
   }
 
-  const ref = node.ref /* Preact 10 */ || node.props.ref /* Preact 8 */ || null;
+  const ref = node.ref /* Preact 10 */ || null;
 
   return {
     nodeType,

--- a/test/Adapter_test.tsx
+++ b/test/Adapter_test.tsx
@@ -1,4 +1,5 @@
-import { VNode, h } from 'preact';
+import { VNode } from 'preact';
+import * as preact from 'preact';
 import { assert } from 'chai';
 import { RSTNode } from 'enzyme';
 
@@ -11,7 +12,7 @@ describe('Adapter', () => {
   it('adds `type` and `props` attributes to VNodes', () => {
     // Add extra properties to vnodes for compatibility with Enzyme.
     new Adapter();
-    const el = h('img', { alt: 'A test image' }) as any;
+    const el = preact.h('img', { alt: 'A test image' }) as any;
     assert.equal(el.type, 'img');
     assert.deepEqual(el.props, {
       alt: 'A test image',

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -1,7 +1,8 @@
-import { Component, h } from 'preact';
+import { Component } from 'preact';
 import { RSTNode } from 'enzyme';
 import { assert } from 'chai';
 import * as sinon from 'sinon';
+import * as preact from 'preact';
 
 import MountRenderer from '../src/MountRenderer';
 import { isPreact10 } from '../src/util';

--- a/test/init.ts
+++ b/test/init.ts
@@ -11,9 +11,6 @@ function setupJSDOM() {
   g.window = dom.window;
   g.document = dom.window.document;
   g.requestAnimationFrame = dom.window.requestAnimationFrame;
-
-  // FIXME - Remove this after upgrading Preact 10 to 10.0.0-beta.2 or later.
-  g.self = dom.window;
 }
 setupJSDOM();
 

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -1,5 +1,6 @@
 import { configure, shallow, mount, render as renderToString } from 'enzyme';
-import { Component, Fragment, h, options, isCompat } from './preact';
+import { Component, Fragment, options, isCompat } from './preact';
+import * as preact from 'preact';
 
 import { assert } from 'chai';
 import * as sinon from 'sinon';
@@ -463,9 +464,9 @@ describe('integration tests', () => {
     });
 
     it('renders children of non-rendered components', () => {
-      function Component() {
+      const Component: any = () => {
         return null;
-      }
+      };
       const wrapper = shallow(
         <div>
           <Component>

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
-import { Component, Fragment, VNode, h } from 'preact';
+import { Component, Fragment, VNode } from 'preact';
+import * as preact from 'preact';
 import { NodeType, RSTNode } from 'enzyme';
 
 import { getNode as getNodeV10, rstNodeFromElement } from '../src/preact10-rst';

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -3,8 +3,14 @@ import { Component, Fragment, VNode } from 'preact';
 import * as preact from 'preact';
 import { NodeType, RSTNode } from 'enzyme';
 
-import { getNode as getNodeV10, rstNodeFromElement } from '../src/preact10-rst';
-import { getNode as getNodeClassic } from '../src/preact8-rst';
+import {
+  getNode as getNodeV10,
+  rstNodeFromElement as rstNodeFromElementV10,
+} from '../src/preact10-rst';
+import {
+  getNode as getNodeV8,
+  rstNodeFromElement as rstNodeFromElementV8,
+} from '../src/preact8-rst';
 import { getType, isPreact10 } from '../src/util';
 import { render } from '../src/compat';
 
@@ -286,9 +292,7 @@ function renderToRST(el: VNode, container?: HTMLElement): RSTNode | null {
     container = document.createElement('div');
   }
   render(el, container);
-  const rootNode = isPreact10()
-    ? getNodeV10(container)
-    : getNodeClassic(container);
+  const rootNode = isPreact10() ? getNodeV10(container) : getNodeV8(container);
   return filterNode(rootNode);
 }
 
@@ -435,6 +439,10 @@ describe('preact8-rst, preact10-rst', () => {
   });
 
   describe('rstNodeFromElement', () => {
+    const rstNodeFromElement = isPreact10()
+      ? rstNodeFromElementV10
+      : rstNodeFromElementV8;
+
     function stripInstances(node: RSTNode | string | null) {
       if (node == null || typeof node === 'string') {
         return node;

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -1,5 +1,6 @@
-import { Component, Fragment, VNode, cloneElement, h } from 'preact';
+import { Component, Fragment, VNode, cloneElement } from 'preact';
 import { assert } from 'chai';
+import * as preact from 'preact';
 
 import {
   getRealType,
@@ -123,9 +124,9 @@ describe('shallow-render-utils', () => {
 
   describe('shallowRenderVNodeTree', () => {
     it('modifies nodes to shallow-render', () => {
-      function Parent() {
+      const Parent: any = () => {
         return null;
-      }
+      };
       function Child() {
         return null;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "jsxFactory": "h",
+    "jsxFactory": "preact.h",
     "module": "commonjs",
     "noUnusedLocals": true,
     "outDir": "build",

--- a/types/preact/index.d.ts
+++ b/types/preact/index.d.ts
@@ -7,17 +7,14 @@ import { ComponentChildren, ComponentFactory, VNode } from 'preact';
 
 declare module 'preact' {
   /**
-   * Preact v10 vnodes.
+   * Preact v8 vnodes.
    */
-  export interface VNode<P = any> {
-    type: ComponentFactory<P>|string|null;
-    text?: string|number|null;
-    ref?: Ref<any>;
-    props: P & { children: ComponentChildren };
-  }
+  export interface VNode<P = {}> {
+		nodeName: ComponentFactory<P> | string;
+		attributes: P;
+		children: Array<VNode<any> | string>;
+		key: Key | null;
 
-  /**
-   * Fragment support was introduced in Preact 10.
-   */
-  const Fragment: ComponentConstructor<{}, {}>;
+    text?: string | number | null;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,15 +1966,15 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-"preact10@npm:preact@^10.0.0":
+"preact8@npm:preact@^8.4.2":
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.2.tgz#2f532da485287c07369e08150cf4d23921a09789"
+  integrity sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg==
+
+preact@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0.tgz#c528f04ac6c792a04d8c98a5144d8b13e0cf2aed"
   integrity sha512-v5geBMq8xlX7Ai8ed0QFXIs7/SQ+4lzdu3fpApRspZ6IiFDRHeEXQ3fqns0jDsXseHjYqgWlK1QxqdWF4QrdFw==
-
-preact@^8.4.2:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.1.tgz#3a86cf5f3d4f6eb3349fa1f106ad59756c2af0e3"
-  integrity sha512-YVnCgcboxGrorFVIPjViqkEPOtfYVDxn5GOJuXHQZiOty+JOw7A+1xJytv/mb1O2QIIRC0SyT+kapA7Wj3jdZA==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR makes Preact 10 the "default" version internally. This means:

- The "preact" dependency is now 10.0.0 and Preact 8 is imported as an alias
- Commands like `yarn test` test against Preact 10 rather than Preact 8. `yarn test:preact8` will test against Preact 8.
- The TypeScript code is written against the Preact 10 typings, with some extensions to support compiling Preact v8 in `types/preact`

Eventually Preact 8 support will be dropped in a major release, although there is no urgency on that and I expect to keep it around in master for a while. To make that easier, the `rstNodeFromElement` internal helper has been split into separate functions for Preact v8 and Preact v10, and a codepaths that were version-specific have been modified to make that more obvious.

There should be no user-facing changes.