### PR TITLE
Ignore preact-render-to-string updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,10 @@
     ],
     "reporter": "html",
     "all": true
+  },
+  "greenkeeper": {
+    "ignore": [
+      "preact-render-to-string"
+    ]
   }
 }


### PR DESCRIPTION
We are sticking with preact-render-to-string v4 to preserve behavior for
Preact v8 + Preact v10. We can reconsider upgrading as part of a
breaking change for one or both of those Preact versions.

See commands in `src/StringRenderer.ts`.