### PR TITLE
Use preact/shared-internals package to query VNodes

### DIFF
--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -1,8 +1,4 @@
-import {
-  AdapterOptions,
-  EnzymeAdapter,
-  RSTNode,
-} from 'enzyme';
+import { AdapterOptions, EnzymeAdapter, RSTNode } from 'enzyme';
 import { ReactElement } from 'react';
 import { VNode, h } from 'preact';
 
@@ -95,7 +91,11 @@ export default class Adapter extends EnzymeAdapter {
     return true;
   }
 
-  createElement(type: string | Function, props: Object, ...children: ReactElement[]) {
+  createElement(
+    type: string | Function,
+    props: Object,
+    ...children: ReactElement[]
+  ) {
     return h(type as any, props, ...children);
   }
 

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -1,40 +1,21 @@
 import { Component, VNode } from 'preact';
+import {
+  getComponentVNode,
+  getChildren,
+} from 'preact/shared-internals';
+export { getChildren, getComponent, getDom as getDOMNode } from 'preact/shared-internals';
 
 /**
  * This module provides access to internal properties of Preact 10 VNodes,
  * components and DOM nodes rendered by Preact.
- *
- * The original property names (in the Preact source) are replaced with shorter
- * ones (they are "mangled") during the build. The mapping from original name to
- * short name is fixed, see `mangle.json` in the Preact source tree.
  */
-
-/**
- * An instance of Preact's `Component` class or a subclass created by
- * rendering.
- */
-interface PreactComponent extends Component {
-  // Original name: `_vnode`.
-  __v: VNode;
-}
 
 /**
  * A DOM element or text node created by Preact as a result of rendering.
  */
 interface PreactNode extends ChildNode {
   // Original name: `_children`.
-  __k: PreactVNode;
-}
-
-interface PreactVNode extends VNode {
-  // Original name: `_dom`.
-  __e: Node | null;
-
-  // Original name: `_component`.
-  __c: Component | null;
-
-  // Original name: `_children`.
-  __k: VNode[] | null;
+  __k: VNode;
 }
 
 /**
@@ -50,31 +31,5 @@ export function getLastVNodeRenderedIntoContainer(container: Node) {
  * Return the VNode returned when `component` was last rendered.
  */
 export function getLastRenderOutput(component: Component) {
-  const preactComponent = component as PreactComponent;
-  return getChildren(preactComponent.__v);
-}
-
-/**
- * Return the rendered DOM node associated with a rendered VNode.
- *
- * "Associated" here means either the DOM node directly output as a result of
- * rendering the vnode (for DOM vnodes) or the first DOM node output by a
- * child vnode for component vnodes.
- */
-export function getDOMNode(node: VNode): Node | null {
-  return (node as PreactVNode).__e;
-}
-
-/**
- * Return the `Component` instance associated with a rendered VNode.
- */
-export function getComponent(node: VNode): Component | null {
-  return (node as PreactVNode).__c;
-}
-
-/**
- * Return the child VNodes associated with a rendered VNode.
- */
-export function getChildren(node: VNode) {
-  return (node as PreactVNode).__k!;
+  return getChildren(getComponentVNode(component));
 }

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -1,4 +1,10 @@
-import { CommonWrapper, configure, shallow, mount, render as renderToString } from 'enzyme';
+import {
+  CommonWrapper,
+  configure,
+  shallow,
+  mount,
+  render as renderToString,
+} from 'enzyme';
 import { Component, Fragment, options, isCompat } from './preact';
 import * as preact from 'preact';
 import { ReactElement } from 'react';
@@ -112,9 +118,7 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
           </Fragment>
         </div>
       );
-      const wrapper = (render(el) as any)
-        .find('div')
-        .children();
+      const wrapper = (render(el) as any).find('div').children();
       assert.equal(wrapper.length, 3);
     });
   }
@@ -176,7 +180,7 @@ function addInteractiveTests(render: typeof mount) {
     let expected: Array<string | Function | undefined>;
     if (render === mount) {
       expected = [Widget, 'div', 'span', undefined];
-    } else if ((render as any)=== shallow) {
+    } else if ((render as any) === shallow) {
       // Shallow rendering omits the top-level component in the output.
       expected = ['div', 'span', undefined];
     } else {


### PR DESCRIPTION
This PR replaces references to mangled private properties of Preact VNodes in preact10-internals.ts with functions from the shared-internals package introduced in https://github.com/preactjs/preact/pull/2160.