### PR TITLE
Fix an exception with render-prop pattern and shallow rendering

### DIFF
--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -1,8 +1,4 @@
-import {
-  AdapterOptions,
-  EnzymeAdapter,
-  RSTNode,
-} from 'enzyme';
+import { AdapterOptions, EnzymeAdapter, RSTNode } from 'enzyme';
 import { ReactElement } from 'react';
 import { VNode, h } from 'preact';
 
@@ -95,7 +91,11 @@ export default class Adapter extends EnzymeAdapter {
     return true;
   }
 
-  createElement(type: string | Function, props: Object, ...children: ReactElement[]) {
+  createElement(
+    type: string | Function,
+    props: Object,
+    ...children: ReactElement[]
+  ) {
     return h(type as any, props, ...children);
   }
 

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -55,6 +55,18 @@ export function getRealType(component: Component) {
 }
 
 /**
+ * Return true if a value is something that can be returned from a render
+ * function.
+ */
+function isRenderable(value: any) {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    (typeof value === 'object' && value.type !== undefined)
+  );
+}
+
+/**
  * Create a dummy component to replace an existing component in rendered output.
  *
  * The dummy renders nothing but has the same display name as the original.
@@ -67,7 +79,12 @@ function makeShallowRenderComponent(
   function ShallowRenderStub({ children }: { children?: any }) {
     if (isPreact10()) {
       // Preact 10 can render fragments, so we can return the children directly.
-      return children;
+      //
+      // There is an exception for `children` values which are not directly
+      // renderable but need to be processed by the component being stubbed.
+      // For example, a function used as part of the "render prop" pattern
+      // (https://reactjs.org/docs/render-props.html).
+      return isRenderable(children) ? children : null;
     }
     // Older versions of Preact need a dummy DOM element to contain the children.
     return h(

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -1,4 +1,10 @@
-import { CommonWrapper, configure, shallow, mount, render as renderToString } from 'enzyme';
+import {
+  CommonWrapper,
+  configure,
+  shallow,
+  mount,
+  render as renderToString,
+} from 'enzyme';
 import { Component, Fragment, options, isCompat } from './preact';
 import * as preact from 'preact';
 import { ReactElement } from 'react';
@@ -112,9 +118,7 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
           </Fragment>
         </div>
       );
-      const wrapper = (render(el) as any)
-        .find('div')
-        .children();
+      const wrapper = (render(el) as any).find('div').children();
       assert.equal(wrapper.length, 3);
     });
   }
@@ -176,7 +180,7 @@ function addInteractiveTests(render: typeof mount) {
     let expected: Array<string | Function | undefined>;
     if (render === mount) {
       expected = [Widget, 'div', 'span', undefined];
-    } else if ((render as any)=== shallow) {
+    } else if ((render as any) === shallow) {
       // Shallow rendering omits the top-level component in the output.
       expected = ['div', 'span', undefined];
     } else {
@@ -482,6 +486,24 @@ describe('integration tests', () => {
       const output = wrapper.debug().replace(/\s+/g, '');
       assert.equal(output, '<div><Component><p>foo</p></Component></div>');
     });
+
+    if (isPreact10()) {
+      it('renders components that take a function as `children`', () => {
+        function Child(props: any) {
+          return props.children();
+        }
+
+        function Parent(props: any) {
+          return <Child>{() => <div>Example</div>}</Child>;
+        }
+
+        let wrapper = shallow(<Parent />);
+        const childrenFunc = wrapper.prop('children') as any;
+        wrapper = shallow(childrenFunc());
+
+        assert.equal(wrapper.text(), 'Example');
+      });
+    }
   });
 
   describe('"string" rendering', () => {


### PR DESCRIPTION
Fix an exception that occurred when shallow rendering stubs a component
that takes a function as the `children` prop. This can happen for
components that implement the "render prop" [1] pattern.

[1] https://reactjs.org/docs/render-props.html