### PR TITLE
Fix regression with array children when using the preact h function directly

### DIFF
--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -61,6 +61,7 @@ export function getRealType(component: Component) {
 function isRenderable(value: any) {
   return (
     value === null ||
+    Array.isArray(value) ||
     typeof value === 'string' ||
     (typeof value === 'object' && value.type !== undefined)
   );

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -487,6 +487,29 @@ describe('integration tests', () => {
       assert.equal(output, '<div><Component><p>foo</p></Component></div>');
     });
 
+    it('renders children of components rendered without JSX', () => {
+      const Component: any = (props: any) => {
+        return (
+          <div>
+            {props.children}
+          </div>
+        );
+      };
+
+      const wrapper = shallow(
+        <div>
+          {
+            preact.h(Component, null,
+              preact.h('p', null, 'foo'),
+              preact.h('p', null, 'bar'),
+            )
+          }
+        </div>
+      );
+      const output = wrapper.debug().replace(/\s+/g, '');
+      assert.equal(output, '<div><Component><p>foo</p><p>bar</p></Component></div>');
+    });
+
     if (isPreact10()) {
       it('renders components that take a function as `children`', () => {
         function Child(props: any) {


### PR DESCRIPTION
I recently upgraded the version of the adapter on a local project of mine and immediately noticed that my snapshot tests were failing for a very specific bit of the codebase. This bit of code in particular was generating component instances using the `preact.h` method directly from a json serialization.

What I managed to track down is that, when doing `h(Foo, null, Child1, Child2)` the children object received in `ShallowRenderStub` is actually an array of the child components. I believe changing `isRenderable` to allow arrays to passthrough should be fine and restore the previous behaviour.