### PR TITLE
Set default event flags appropriate for event type

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -2,6 +2,7 @@ import { MountRenderer as AbstractMountRenderer, RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 import { act } from 'preact/test-utils';
 
+import { eventData } from './event-data';
 import { getNode } from './preact10-rst';
 import { getDisplayName, withReplacedMethod } from './util';
 import { render } from './compat';
@@ -19,6 +20,15 @@ export interface Options {
    * If not specified, a detached element (not connected to the body) is used.
    */
   container?: HTMLElement;
+}
+
+function constructEvent(type: string, init: EventInit) {
+  const meta = eventData[type];
+  const defaultInit = meta?.defaultInit ?? {};
+  return new Event(type, {
+    ...defaultInit,
+    ...init,
+  });
 }
 
 export default class MountRenderer implements AbstractMountRenderer {
@@ -92,11 +102,17 @@ export default class MountRenderer implements AbstractMountRenderer {
     // constructor for the event type. This implementation is good enough for
     // many components though.
     const { bubbles, composed, cancelable, ...extra } = args;
-    const event = new Event(eventName, {
-      bubbles,
-      composed,
-      cancelable,
-    });
+    const init = {} as EventInit;
+    if (typeof bubbles === 'boolean') {
+      init.bubbles = bubbles;
+    }
+    if (typeof composed === 'boolean') {
+      init.composed = composed;
+    }
+    if (typeof cancelable === 'boolean') {
+      init.cancelable = cancelable;
+    }
+    const event = constructEvent(eventName, init);
     Object.assign(event, extra);
 
     act(() => {

--- a/src/event-data.ts
+++ b/src/event-data.ts
@@ -1,0 +1,300 @@
+export interface EventData {
+  EventType: string;
+  defaultInit: EventInit;
+}
+
+/**
+ * Metadata for events which have different flags set by default than the
+ * `Event` constructor defaults or which use a subclass of `Event`.
+ *
+ * Adapted from `event-data.js` in https://github.com/testing-library/dom-testing-library.
+ */
+export const eventData: Record<string, EventData> = {
+  // Clipboard Events
+  copy: {
+    EventType: 'ClipboardEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  cut: {
+    EventType: 'ClipboardEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  paste: {
+    EventType: 'ClipboardEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+
+  // Composition Events
+  compositionend: {
+    EventType: 'CompositionEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  compositionstart: {
+    EventType: 'CompositionEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  compositionupdate: {
+    EventType: 'CompositionEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+
+  // Keyboard Events
+  keydown: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    },
+  },
+  keypress: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    },
+  },
+  keyup: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    },
+  },
+
+  // Focus Events
+  focus: {
+    EventType: 'FocusEvent',
+    defaultInit: { bubbles: false, cancelable: false, composed: true },
+  },
+  blur: {
+    EventType: 'FocusEvent',
+    defaultInit: { bubbles: false, cancelable: false, composed: true },
+  },
+  focusin: {
+    EventType: 'FocusEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  focusout: {
+    EventType: 'FocusEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+
+  // Form Events
+  change: {
+    EventType: 'Event',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+  input: {
+    EventType: 'InputEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  invalid: {
+    EventType: 'Event',
+    defaultInit: { bubbles: false, cancelable: true },
+  },
+  submit: {
+    EventType: 'Event',
+    defaultInit: { bubbles: true, cancelable: true },
+  },
+  reset: {
+    EventType: 'Event',
+    defaultInit: { bubbles: true, cancelable: true },
+  },
+
+  // Mouse Events
+  click: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  contextmenu: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  dblclick: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  drag: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  dragend: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  dragenter: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  dragexit: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  dragleave: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  dragover: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  dragstart: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  drop: {
+    EventType: 'DragEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  mousedown: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  mouseenter: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: false, cancelable: false, composed: true },
+  },
+  mouseleave: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: false, cancelable: false, composed: true },
+  },
+  mousemove: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  mouseout: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  mouseover: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  mouseup: {
+    EventType: 'MouseEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+
+  // Selection Events
+  select: {
+    EventType: 'Event',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+
+  // Touch Events
+  touchcancel: {
+    EventType: 'TouchEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  touchend: {
+    EventType: 'TouchEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  touchmove: {
+    EventType: 'TouchEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  touchstart: {
+    EventType: 'TouchEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+
+  // UI Events
+  scroll: {
+    EventType: 'UIEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+
+  // Wheel Events
+  wheel: {
+    EventType: 'WheelEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+
+  // Media Events
+  loadstart: {
+    EventType: 'ProgressEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+  progress: {
+    EventType: 'ProgressEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+
+  // Image Events
+  load: {
+    EventType: 'UIEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+
+  // Animation Events
+  animationstart: {
+    EventType: 'AnimationEvent',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+  animationend: {
+    EventType: 'AnimationEvent',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+  animationiteration: {
+    EventType: 'AnimationEvent',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+
+  // Transition Events
+  transitionend: {
+    EventType: 'TransitionEvent',
+    defaultInit: { bubbles: true, cancelable: true },
+  },
+
+  // Pointer events
+  pointerover: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  pointerenter: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+  pointerdown: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  pointermove: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  pointerup: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  pointercancel: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  pointerout: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: true, composed: true },
+  },
+  pointerleave: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: false, cancelable: false },
+  },
+  gotpointercapture: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+  lostpointercapture: {
+    EventType: 'PointerEvent',
+    defaultInit: { bubbles: true, cancelable: false, composed: true },
+  },
+
+  // History events
+  popstate: {
+    EventType: 'PopStateEvent',
+    defaultInit: { bubbles: true, cancelable: false },
+  },
+};

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -185,6 +185,44 @@ describe('MountRenderer', () => {
       sinon.assert.called(callback);
     });
 
+    [
+      {
+        type: 'click',
+        bubbles: true,
+        cancelable: true,
+      },
+      {
+        type: 'focus',
+        bubbles: false,
+        cancelable: false,
+      },
+      {
+        type: 'animationstart',
+        bubbles: true,
+        cancelable: false,
+      },
+      {
+        type: 'somecustomevent',
+        bubbles: false,
+        cancelable: false,
+      },
+    ].forEach(({ type, bubbles, cancelable }) => {
+      it('sets default event properties based on event type', () => {
+        const renderer = new MountRenderer();
+        const callback = sinon.stub();
+        const eventProp = 'on' + type;
+        const props = { [eventProp]: callback };
+        renderer.render(<button type="button" {...props} />);
+
+        renderer.simulateEvent(renderer.getNode() as RSTNode, type, {});
+
+        sinon.assert.calledOnce(callback);
+        const event = callback.getCall(0).args[0];
+        assert.equal(event.bubbles, bubbles);
+        assert.equal(event.cancelable, cancelable);
+      });
+    });
+
     it('passes arguments to event handler', () => {
       const renderer = new MountRenderer();
       const callback = sinon.stub();


### PR DESCRIPTION
Set the `bubbles`, `cancelable` and `composed` flags to match the
default value of these flags for a given event type.

 - Add a metadata map in `src/event-data.ts` which is adapted from
   `dom-testing-library` and describes the default init args and
   constructors for different events.

   Note that the event constructor is not currently used. That will
   happen separately.

 - Use this metadata in `MountRenderer` to set the default arguments
   passed to the `Event` constructor's second argument, unless
   overridden

Fixes https://github.com/preactjs/enzyme-adapter-preact-pure/issues/129

----

**TODO:**

- [ ] Review the correctness / completeness of the `event-data.ts` data