### PR TITLE
Support `invoke` API

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -111,4 +111,12 @@ export default class MountRenderer implements AbstractMountRenderer {
   container() {
     return this._container;
   }
+
+  wrapInvoke(callback: () => any) {
+    let result;
+    act(() => {
+      result = callback();
+    });
+    return result;
+  }
 }

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -212,4 +212,16 @@ describe('MountRenderer', () => {
       });
     });
   });
+
+  describe('#wrapInvoke', () => {
+    it('returns result of callback', () => {
+      const Widget = () => <div />;
+      const renderer = new MountRenderer();
+      renderer.render(<Widget />);
+
+      const result = renderer.wrapInvoke(() => 'test');
+
+      assert.equal(result, 'test');
+    });
+  });
 });

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'enzyme';
 import { Component, Fragment, options } from './preact';
 import * as preact from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import { ReactElement } from 'react';
 
 import { assert } from 'chai';
@@ -400,6 +401,28 @@ describe('integration tests', () => {
       const wrapper = mount(<button />, { attachTo: container });
       assert.ok(container.querySelector('button'));
       wrapper.detach();
+    });
+
+    it('flushes effects and state updates when using `invoke`', () => {
+      let effectCount = 0;
+
+      const Child = ({ children, onClick }: any) => (
+        <button onClick={onClick}>{children}</button>
+      );
+      const Parent = () => {
+        const [count, setCount] = useState(0);
+        useEffect(() => {
+          effectCount = count;
+        }, [count]);
+        return <Child onClick={() => setCount(c => c + 1)}>{count}</Child>;
+      };
+
+      const wrapper = mount(<Parent />);
+      // @ts-ignore - `onClick` type is wrong
+      wrapper.find('Child').invoke('onClick')();
+
+      assert.equal(wrapper.text(), '1');
+      assert.equal(effectCount, 1);
     });
   });
 


### PR DESCRIPTION
Support the `invoke` API [1] introduced in Enzyme v3.11.0 that invokes a
prop function within an `act` call and then updates the wrapper afterwards.

Currently `invoke` is only supported _by this adapter_ in `mount` rendering. (Edit: Clarified that this is a limitation of this adapter, not Enzyme generally)

[1] https://github.com/enzymejs/enzyme/blob/master/docs/api/ReactWrapper/invoke.md