### PR TITLE
Use type-only imports from Enzyme where possible

### DIFF
--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -1,5 +1,6 @@
-import { AdapterOptions, EnzymeAdapter, RSTNode } from 'enzyme';
-import { ReactElement } from 'react';
+import type { AdapterOptions, RSTNode } from 'enzyme';
+import { EnzymeAdapter } from 'enzyme';
+import type { ReactElement } from 'react';
 import { VNode, h } from 'preact';
 
 import MountRenderer from './MountRenderer';

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -1,4 +1,4 @@
-import { MountRenderer as AbstractMountRenderer, RSTNode } from 'enzyme';
+import type { MountRenderer as AbstractMountRenderer, RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 import { act } from 'preact/test-utils';
 

--- a/src/StringRenderer.ts
+++ b/src/StringRenderer.ts
@@ -1,5 +1,5 @@
-import { Renderer, RSTNode } from 'enzyme';
-import { ReactElement } from 'react';
+import type { Renderer, RSTNode } from 'enzyme';
+import type { ReactElement } from 'react';
 import { h, render } from 'preact';
 
 export default class StringRenderer implements Renderer {

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -8,7 +8,7 @@
  * The rendered result is converted to RST by traversing these vnode references.
  */
 
-import { NodeType, RSTNode } from 'enzyme';
+import type { NodeType, RSTNode } from 'enzyme';
 import { Component, Fragment, VNode } from 'preact';
 import flatMap from 'array.prototype.flatmap';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { RSTNode } from 'enzyme';
+import type { RSTNode } from 'enzyme';
 import { VNode } from 'preact';
 
 export function getType(obj: Object) {

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -8,7 +8,7 @@ import {
 import { Component, Fragment, options } from './preact';
 import * as preact from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 import { assert } from 'chai';
 import * as sinon from 'sinon';


### PR DESCRIPTION
Make it easier to see where this adapter has a dependency on Enzyme's
implementation vs. just interfaces.