### PR TITLE
Add ES module build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .nyc_output/
 build/
+build-cjs/
 coverage/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "enzyme-adapter-preact-pure",
   "version": "3.1.0",
   "description": "Enzyme adapter for Preact",
-  "main": "build/src/index.js",
+  "main": "build-cjs/src/index.js",
+  "module": "build/src/index.js",
   "repository": "https://github.com/preactjs/enzyme-adapter-preact-pure",
   "author": "Robert Knight",
   "license": "MIT",
@@ -24,7 +25,6 @@
     "prettier": "2.0.0",
     "sinon": "^7.2.3",
     "source-map-support": "^0.5.12",
-    "ts-node": "^8.0.2",
     "typescript": "^3.3.3",
     "yalc": "^1.0.0-pre.34"
   },
@@ -33,11 +33,12 @@
     "preact": "^10.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build tsconfig.json",
+    "build-cjs": "tsc --build tsconfig-cjs.json",
     "checkformatting": "prettier --check src/**/*.ts test/**/*.{ts,tsx}",
     "format": "prettier --list-different --write src/**/*.ts test/**/*.{ts,tsx}",
-    "prepublish": "rm -rf build && yarn run build",
-    "test": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"esnext\"}' nyc mocha -r ts-node/register/transpile-only -r source-map-support/register -r test/init.ts test/*.tsx",
+    "prepublish": "rm -rf build && yarn build && yarn build-cjs",
+    "test": "yarn build-cjs && nyc mocha -r build-cjs/test/init.js build-cjs/test/*.js",
     "test:compat": "yarn test --preact-compat-lib preact/compat"
   },
   "dependencies": {

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "outDir": "build-cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,15 +4,13 @@
     "esModuleInterop": true,
     "jsx": "react",
     "jsxFactory": "preact.h",
-    "module": "commonjs",
+    "module": "es2020",
+    "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "build",
     "strict": true,
-    "target": "es5",
+    "target": "es2020",
     "typeRoots": ["types", "node_modules/@types"]
   },
-  "exclude": [
-    "build",
-    "examples"
-  ]
+  "exclude": ["build", "build-cjs", "examples"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,11 +286,6 @@ archy@^1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -687,11 +682,6 @@ diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -1599,11 +1589,6 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@^1.1.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -2303,7 +2288,7 @@ sinon@^7.2.3:
     nise "^1.5.2"
     supports-color "^5.5.0"
 
-source-map-support@^0.5.12, source-map-support@^0.5.17:
+source-map-support@^0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -2551,17 +2536,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-ts-node@^8.0.2:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -2836,8 +2810,3 @@ yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "5.0.0-security.0"
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Change the main build to generate ES modules rather than CommonJS. The
CommonJS build is still generated for backwards compatibility and will
be removed in a future major release.

The tests currently use the CommonJS build because that was easier to
get working. They should be changed to use the ESM build in future.