### PR TITLE
Upgrade Preact dependency used in tests to v10.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "minimist": "^1.2.0",
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
-    "preact": "^10.0.4",
+    "preact": "^10.5.15",
     "prettier": "2.0.0",
     "sinon": "^11.1.2",
     "source-map-support": "^0.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2273,10 +2273,10 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-preact@^10.0.4:
-  version "10.4.6"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.6.tgz#86cc43396e4bdd755726a2b4b1f0529e78067cd3"
-  integrity sha512-80WJfXH53yyINig5Wza/8MD9n4lMg9G6aN00ws0ptsAaY/Fu/M7xW4zICf7OLfocVltxS30wvNQ8oIbUyZS1tw==
+preact@^10.5.15:
+  version "10.5.15"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
+  integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This fixes an error I observed locally in one test:

```
  1) preact10-rst
       getNode
         returns expected RST node (component that renders children):
     TypeError: Found non-callable @@iterator
```

I didn't dig into the exact cause of the above, but the test did not fail when
run recently in CI and I have upgraded to Node v17 locally since. Using
a current version of Preact in tests is a good idea in any case.

In the process another test started failing due to the addition of an
internal ID counter to VNodes. This test was adapted to ignore the field
when comparing values.