### PR TITLE
Support wrappingComponent & wrappingComponentProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ declare module 'enzyme' {
     // Required methods.
     createElement(
       type: string | Function,
-      props: Object,
+      props: Object | null,
       ...children: ReactElement[]
     ): ReactElement;
     createRenderer(options: AdapterOptions): Renderer;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/mocha": "^9.0.0",
     "@types/sinon": "^10.0.6",
     "chai": "^4.3.4",
-    "enzyme": "^3.8.0",
+    "enzyme": "^3.11.0",
     "jsdom": "^16.0.1",
     "minimist": "^1.2.0",
     "mocha": "^9.1.3",
@@ -29,7 +29,7 @@
     "yalc": "^1.0.0-pre.34"
   },
   "peerDependencies": {
-    "enzyme": "^3.8.0",
+    "enzyme": "^3.11.0",
     "preact": "^10.0.0"
   },
   "scripts": {

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -114,11 +114,11 @@ export default class Adapter extends EnzymeAdapter {
     node: ReactElement,
     /**
      * Tip:
-     * The use of `wrappingComponent` and `wrappingComponentProps` is discouraged!
+     * The use of `wrappingComponent` and `wrappingComponentProps` is discouraged.
      * Using those props complicates a potential future migration to a different testing library.
      * Instead, wrap a component like this:
      * ```
-     * shallow(<Wrapper><Component/></Wrapper>)
+     * shallow(<Wrapper><Component/></Wrapper>).dive()
      * ```
      */
     options?: ShallowRendererProps

--- a/src/RootFinder.ts
+++ b/src/RootFinder.ts
@@ -1,11 +1,6 @@
 import { Component } from 'preact';
 
-export default class RootFinder extends Component<{ context: any }> {
-  // I'm not sure if this is needed… It might help with legacy context 🤷
-  getChildContext() {
-    return this.props.context;
-  }
-
+export default class RootFinder extends Component {
   render() {
     return this.props.children;
   }

--- a/src/RootFinder.ts
+++ b/src/RootFinder.ts
@@ -1,0 +1,12 @@
+import { Component } from 'preact';
+
+export default class RootFinder extends Component<{ context: any }> {
+  // I'm not sure if this is needed… It might help with legacy context 🤷
+  getChildContext() {
+    return this.props.context;
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/src/wrapWithWrappingComponent.ts
+++ b/src/wrapWithWrappingComponent.ts
@@ -9,7 +9,7 @@ export default function wrapWithWrappingComponent(
   node: ReactElement,
   options: ShallowRendererProps = {}
 ) {
-  const { wrappingComponent, wrappingComponentProps = {}, context } = options;
+  const { wrappingComponent, wrappingComponentProps = {} } = options;
 
   if (!wrappingComponent) {
     return node;
@@ -24,15 +24,9 @@ export default function wrapWithWrappingComponent(
     nodeWithValidChildren.props.children = childElements(nodeWithValidChildren);
   }
 
-  const rootFinderContext =
-    (wrappingComponentProps as { context: any })?.context || context;
-  const rootFinderProps = rootFinderContext
-    ? { context: rootFinderContext }
-    : null;
-
   return createElement(
     wrappingComponent,
     wrappingComponentProps,
-    createElement(RootFinder, rootFinderProps, nodeWithValidChildren)
+    createElement(RootFinder, null, nodeWithValidChildren)
   );
 }

--- a/src/wrapWithWrappingComponent.ts
+++ b/src/wrapWithWrappingComponent.ts
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import type { EnzymeAdapter, ShallowRendererProps } from 'enzyme';
 import RootFinder from './RootFinder.js';
 import { childElements } from './compat.js';
+import { cloneElement } from 'preact';
 
 /** Based on the equivalent function in `enzyme-adapter-utils` */
 export default function wrapWithWrappingComponent(
@@ -19,9 +20,15 @@ export default function wrapWithWrappingComponent(
 
   if (typeof nodeWithValidChildren.props.children === 'string') {
     // This prevents an error when `.dive()` is used:
-    // `TypeError: ShallowWrapper::dive() can only be called on components`
-    nodeWithValidChildren = Object.assign({}, nodeWithValidChildren);
-    nodeWithValidChildren.props.children = childElements(nodeWithValidChildren);
+    // `TypeError: ShallowWrapper::dive() can only be called on components`.
+    // ---------------------------------------------------------------------
+    // VNode before: `{ type: Widget, props: { children: 'test' }, ... }`
+    // VNode after:  `{ type: Widget, props: { children: ['test'] }, ... }`
+    nodeWithValidChildren = cloneElement(
+      nodeWithValidChildren,
+      nodeWithValidChildren.props,
+      childElements(nodeWithValidChildren)
+    );
   }
 
   return createElement(

--- a/src/wrapWithWrappingComponent.ts
+++ b/src/wrapWithWrappingComponent.ts
@@ -1,0 +1,38 @@
+import type { ReactElement } from 'react';
+import type { EnzymeAdapter, ShallowRendererProps } from 'enzyme';
+import RootFinder from './RootFinder.js';
+import { childElements } from './compat.js';
+
+/** Based on the equivalent function in `enzyme-adapter-utils` */
+export default function wrapWithWrappingComponent(
+  createElement: EnzymeAdapter['createElement'],
+  node: ReactElement,
+  options: ShallowRendererProps = {}
+) {
+  const { wrappingComponent, wrappingComponentProps = {}, context } = options;
+
+  if (!wrappingComponent) {
+    return node;
+  }
+
+  let nodeWithValidChildren = node;
+
+  if (typeof nodeWithValidChildren.props.children === 'string') {
+    // This prevents an error when `.dive()` is used:
+    // `TypeError: ShallowWrapper::dive() can only be called on components`
+    nodeWithValidChildren = Object.assign({}, nodeWithValidChildren);
+    nodeWithValidChildren.props.children = childElements(nodeWithValidChildren);
+  }
+
+  const rootFinderContext =
+    (wrappingComponentProps as { context: any })?.context || context;
+  const rootFinderProps = rootFinderContext
+    ? { context: rootFinderContext }
+    : null;
+
+  return createElement(
+    wrappingComponent,
+    wrappingComponentProps,
+    createElement(RootFinder, rootFinderProps, nodeWithValidChildren)
+  );
+}

--- a/test/Adapter_test.tsx
+++ b/test/Adapter_test.tsx
@@ -215,4 +215,54 @@ describe('Adapter', () => {
       });
     });
   });
+
+  describe('#wrapWithWrappingComponent', () => {
+    function Button() {
+      return <button>Click me</button>;
+    }
+
+    function WrappingComponent({
+      children,
+      ...wrappingComponentProps
+    }: {
+      children: preact.ComponentChildren;
+    }) {
+      return <div {...wrappingComponentProps}>{children}</div>;
+    }
+
+    it('returns original component when not wrapped', () => {
+      const button = <Button />;
+      const adapter = new Adapter();
+      const hostNode = adapter.wrapWithWrappingComponent(button);
+
+      assert.ok(hostNode);
+      assert.typeOf(hostNode.RootFinder, 'function');
+      assert.deepEqual(hostNode.node, button);
+    });
+
+    it('returns wrapped component', () => {
+      const button = <Button />;
+      const wrappingComponentProps = { foo: 'bar' };
+      const wrappedComponent = (
+        <WrappingComponent {...wrappingComponentProps}>
+          {button}
+        </WrappingComponent>
+      );
+
+      const adapter = new Adapter();
+      const hostNode = adapter.wrapWithWrappingComponent(button, {
+        wrappingComponent: WrappingComponent,
+        wrappingComponentProps,
+      });
+
+      assert.ok(hostNode);
+
+      const rootFinderInHostNode = hostNode.node.props.children.type;
+      assert.equal(hostNode.RootFinder, rootFinderInHostNode);
+
+      const buttonInWrappedComponent = wrappedComponent.props.children;
+      const buttonInHostNode = hostNode.node.props.children.props.children;
+      assert.equal(buttonInHostNode, buttonInWrappedComponent);
+    });
+  });
 });

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -262,4 +262,41 @@ describe('MountRenderer', () => {
       assert.equal(result, 'test');
     });
   });
+
+  describe('getNode', () => {
+    it('can get the node', () => {
+      const renderedTree = [
+        {
+          nodeType: 'host',
+          type: 'div',
+          props: {},
+          key: null,
+          ref: null,
+          instance: document.createElement('span'),
+          rendered: [],
+        },
+      ];
+
+      const Widget = () => <span />;
+      const renderer = new MountRenderer();
+      renderer.render(<Widget />);
+
+      const result = renderer.getWrappingComponentRenderer();
+
+      assert.equal(result.getNode()?.rendered.length, 1);
+
+      const resultInstance = (result.getNode()?.rendered[0] as RSTNode)
+        .instance;
+      const expectedInstance = renderedTree[0].instance;
+
+      assert.equal(resultInstance.toString(), expectedInstance.toString());
+      assert.equal(resultInstance.nodeType, expectedInstance.nodeType);
+      assert.equal(resultInstance.nodeName, expectedInstance.nodeName);
+      assert.equal(resultInstance.nodeValue, expectedInstance.nodeValue);
+      assert.equal(
+        resultInstance.childNodes.length,
+        expectedInstance.childNodes.length
+      );
+    });
+  });
 });

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -289,14 +289,7 @@ describe('MountRenderer', () => {
         .instance;
       const expectedInstance = renderedTree[0].instance;
 
-      assert.equal(resultInstance.toString(), expectedInstance.toString());
-      assert.equal(resultInstance.nodeType, expectedInstance.nodeType);
-      assert.equal(resultInstance.nodeName, expectedInstance.nodeName);
-      assert.equal(resultInstance.nodeValue, expectedInstance.nodeValue);
-      assert.equal(
-        resultInstance.childNodes.length,
-        expectedInstance.childNodes.length
-      );
+      assert.equal(resultInstance.outerHTML, expectedInstance.outerHTML);
     });
   });
 });

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -2,13 +2,17 @@ import type { CommonWrapper } from 'enzyme';
 import enzyme from 'enzyme';
 import { Component, Fragment, options } from 'preact';
 import * as preact from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import type { ReactElement } from 'react';
 
 import { assert } from 'chai';
 import sinon from 'sinon';
 
 import Adapter from '../src/Adapter.js';
+
+const TestContext = preact.createContext<{ myTestString: string }>({
+  myTestString: 'default',
+});
 
 const { configure, shallow, mount, render: renderToString } = enzyme;
 
@@ -453,6 +457,24 @@ describe('integration tests', () => {
       assert.equal(
         output,
         '<WrappingComponent foo="bar"><div foo="bar"><Component><span>test</span></Component></div></WrappingComponent>'
+      );
+    });
+
+    it('passes context to mounted component wrapped with provider', () => {
+      function Component() {
+        const { myTestString } = useContext(TestContext);
+        return <span>{myTestString}</span>;
+      }
+
+      const wrapper = mount(<Component />, {
+        wrappingComponent: TestContext.Provider,
+        wrappingComponentProps: { value: { myTestString: 'override' } },
+      });
+
+      const output = normalizeDebugMessage(wrapper.debug());
+      assert.equal(
+        output,
+        '<Provider value={{...}}><Component><span>override</span></Component></Provider>'
       );
     });
   });

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -523,29 +523,14 @@ describe('integration tests', () => {
       );
     });
 
-    it('passes context option to RootFinder', () => {
-      function Component() {
-        return <span>test</span>;
-      }
-      const wrapper = shallow(<Component />, {
-        wrappingComponent: WrappingComponent,
-        context: { test: 'abc' },
-      });
-
-      const output = debugWrappedComponent(wrapper);
-      assert.equal(
-        output,
-        '<div><RootFinder context={{...}}><Component /></RootFinder></div>'
-      );
-    });
-
-    it('passes wrappingComponentProps.context option to wrappingComponent and RootFinder', () => {
+    it('passes wrappingComponentProps to wrappingComponent', () => {
       function Component() {
         return <span>test</span>;
       }
       const wrapper = shallow(<Component />, {
         wrappingComponent: WrappingComponent,
         wrappingComponentProps: {
+          foo: 'bar',
           context: { test: 'abc' },
         },
       });
@@ -553,7 +538,7 @@ describe('integration tests', () => {
       const output = debugWrappedComponent(wrapper);
       assert.equal(
         output,
-        '<div context={{...}}><RootFinder context={{...}}><Component /></RootFinder></div>'
+        '<div foo="bar" context={{...}}><RootFinder><Component /></RootFinder></div>'
       );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,7 +970,7 @@ enzyme-shallow-equal@^1.0.1:
     has "^1.0.3"
     object-is "^1.0.2"
 
-enzyme@^3.8.0:
+enzyme@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
   integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==


### PR DESCRIPTION
Support for `wrappingComponent` has been requested in https://github.com/preactjs/enzyme-adapter-preact-pure/issues/99 and this PR adds it for components rendered using the `shallow` and `mount` Enzyme utils.

## How was this tested?
1. I added tests to the project and all are passing.
2. I verified that the changes in this PR solve the issue for my organization, allowing us to use `wrappingComponent` and `wrappingComponentProps` for both `shallow` and `mount` components.

Note for my future self: this is how I verified the changes locally…
- Make sure `yalc` is installed (as recommended in the [contributing guide](https://github.com/preactjs/enzyme-adapter-preact-pure/blob/master/CONTRIBUTING.md)): `yarn global add yalc`
- Run `yalc publish` in the (forked) project locally.
- Run this in the other project where the dependency should be tested: `yalc add enzyme-adapter-preact-pure`. This updates the package.json and lock file. Then run `yarn install`.
- After making a change, run `yalc publish --push` and the other project will use the latest code

Tips for faster development:
- Auto-run tests on file change: `nodemon --watch "test/**" --watch "src/**"  --ext "ts,tsx" --exec yarn test`
- Auto-publish on file change: `nodemon --watch "src/**"  --ext "ts" --exec "yalc publish --push --changed"`