### PR TITLE
Upgrade TypeScript to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/array.prototype.flatmap": "^1.2.0",
     "@types/chai": "^4.1.7",
     "@types/enzyme": "^3.10.3",
-    "@types/jsdom": "^16.1.0",
+    "@types/jsdom": "^16.2.14",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^9.0.0",
     "@types/sinon": "^10.0.6",
@@ -25,7 +25,7 @@
     "prettier": "2.0.0",
     "sinon": "^11.1.2",
     "source-map-support": "^0.5.12",
-    "typescript": "^3.3.3",
+    "typescript": "^4.6.3",
     "yalc": "^1.0.0-pre.34"
   },
   "peerDependencies": {

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -16,7 +16,7 @@ function Parent({ label }: any) {
 }
 
 function Section({ children }: any) {
-  return <section>{...children}</section>;
+  return <section>{children}</section>;
 }
 
 class ClassComponent extends Component<{ label: string }> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,10 +277,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/jsdom@^16.1.0":
-  version "16.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.3.tgz#c6feadfe0836389b27f9c911cde82cd32e91c537"
-  integrity sha512-BREatezSn74rmLIDksuqGNFUTi9HNAWWQXYpFBFLK9U6wlMCO4M0QCa8CMpDsZQuqxSO9XifVLT5Q1P0vgKLqw==
+"@types/jsdom@^16.2.14":
+  version "16.2.14"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.14.tgz#26fe9da6a8870715b154bb84cd3b2e53433d8720"
+  integrity sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==
   dependencies:
     "@types/node" "*"
     "@types/parse5" "*"
@@ -2808,10 +2808,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.3.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This required an @types/jsdom update for compatibility, as well as a
change in a test to avoid a `Found non-callable @iterator` error.