### PR TITLE
Update CommonJS build target to ES 2020 and remove Array.flatMap polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     "test-cjs": "yarn build-cjs && nyc mocha -r build-cjs/test/init.js build-cjs/test/*.js",
     "test:compat": "yarn test --preact-compat-lib preact/compat"
   },
-  "dependencies": {
-    "array.prototype.flatmap": "^1.2.1"
-  },
+  "dependencies": {},
   "files": [
     "build/src/**/*",
     "build-cjs/src/**/*",

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -10,7 +10,6 @@
 
 import type { NodeType, RSTNode } from 'enzyme';
 import { Component, Fragment, VNode } from 'preact';
-import flatMap from 'array.prototype.flatmap';
 
 import { childElements } from './compat.js';
 import {
@@ -47,7 +46,7 @@ function rstNodesFromChildren(nodes: (VNode | null)[] | null): RSTNodeTypes[] {
   if (!nodes) {
     return [];
   }
-  return flatMap(nodes, (node: VNode | null) => {
+  return nodes.flatMap(node => {
     if (node === null) {
       // The array of rendered children may have `null` entries as a result of
       // eg. conditionally rendered children where the condition was false.

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
     "outDir": "build-cjs"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,15 +451,6 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-array.prototype.flatmap@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
-  integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"


### PR DESCRIPTION
Set the JS version targeted by the CommonJS build to be the same as the ESM build (ES 2020). This reduces the complexity of the testing matrix.

Also remove the Array.flatMap polyfill. This is included in ES2020 and has been supported natively since Node v11, Chrome 69, Firefox 62 and Safari 12.