### PR TITLE
Add explicit cast from VNode to ReactElement type

### DIFF
--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -60,7 +60,7 @@ export default class Adapter extends EnzymeAdapter {
       return node;
     }
     const childElements = node.rendered.map(n => this.nodeToElement(n as any));
-    return h(node.type as any, node.props, ...childElements);
+    return h(node.type as any, node.props, ...childElements) as ReactElement;
   }
 
   nodeToHostNode(node: RSTNode | string): Node | null {
@@ -101,8 +101,8 @@ export default class Adapter extends EnzymeAdapter {
     type: string | Function,
     props: Object | null,
     ...children: ReactElement[]
-  ) {
-    return h(type as any, props, ...children);
+  ): ReactElement {
+    return h(type as any, props, ...children) as ReactElement;
   }
 
   elementToNode(el: ReactElement): RSTNode {


### PR DESCRIPTION
This suppresses a TypeScript error when using @types/react v18. See https://github.com/preactjs/enzyme-adapter-preact-pure/issues/161#issuecomment-1097961763.

The @types/react transitive dependency in this package has not yet been
updated because there are TS errors in tests when trying to pass JSX
elements to functions that expect a ReactElement.

```
Type 'VNode<any>' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
  Types of property 'type' are incompatible.
    Type 'string | ComponentType<any>' is not assignable to type 'string | JSXElementConstructor<any>'.
      Type 'ComponentClass<any, {}>' is not assignable to type 'string | JSXElementConstructor<any>'.
        Type 'ComponentClass<any, {}>' is not assignable to type 'new (props: any) => Component<any, any, any>'.
          Construct signature return types 'Component<any, {}>' and 'Component<any, any, any>' are incompatible.
            The types returned by 'render(...)' are incompatible between these types.
              Type 'ComponentChild' is not assignable to type 'ReactNode'.
                Type 'bigint' is not assignable to type 'ReactNode'.
```