### PR TITLE
Change various "Preact 10" references to Preact

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,11 @@ wrapper.update();
 // Test that parent component updated as expected.
 ```
 
-When using the [Hooks](https://reactjs.org/docs/hooks-intro.html) API which is
-available in React 16.8+ and Preact 10, you also need to wrap any code which
-triggers effects in an [act](https://reactjs.org/docs/test-utils.html#act) call
-in order to flush effects and trigger a re-render. The initial render and calls
-to APIs such as `setProps` or `simulate` are automatically wrapped in `act`
-for you.
+When using the [Hooks](https://reactjs.org/docs/hooks-intro.html) API you also
+need to wrap any code which triggers effects in an
+[act](https://reactjs.org/docs/test-utils.html#act) call in order to flush
+effects and trigger a re-render. The initial render and calls to APIs such as
+`setProps` or `simulate` are automatically wrapped in `act` for you.
 
 In Preact the `act` function is available in the "preact/test-utils" package.
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -49,9 +49,9 @@ function findVNodeForDOM(
  * Find the `Component` instance that produced a given DOM node.
  */
 export function componentForDOMNode(el: Node): Component | null {
-  // In Preact 10 we have to search up the tree until we find the container
-  // that the root vnode was rendered into, then traverse the vnode tree to
-  // find the component vnode that produced the DOM element.
+  // Search up the tree until we find the container that the root vnode was
+  // rendered into, then traverse the vnode tree to find the component vnode
+  // that produced the DOM element.
   let parentEl = el.parentNode;
   let rootVNode = null;
   while (parentEl && !rootVNode) {

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -1,9 +1,8 @@
 /**
- * Functions for rendering components using Preact "X" (v10 and later) and
- * converting the result to a React Standard Tree (RST) format defined by
- * Enzyme.
+ * Functions for rendering components using Preact v10 and converting the result
+ * to a React Standard Tree (RST) format defined by Enzyme.
  *
- * Preact 10+ stores details of the rendered elements on internal fields of
+ * Preact 10 stores details of the rendered elements on internal fields of
  * the VNodes. A reference to the vnode is stored in the root DOM element.
  * The rendered result is converted to RST by traversing these vnode references.
  */

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -71,7 +71,7 @@ function makeShallowRenderComponent(
   type: ComponentFactory<any>
 ): ShallowRenderFunction {
   function ShallowRenderStub({ children }: { children?: any }) {
-    // Preact 10 can render fragments, so we can return the children directly.
+    // Preact can render fragments, so we can return the children directly.
     //
     // There is an exception for `children` values which are not directly
     // renderable but need to be processed by the component being stubbed.

--- a/test/init.ts
+++ b/test/init.ts
@@ -3,7 +3,7 @@ import minimist from 'minimist';
 
 // Setup DOM globals required by Preact rendering.
 function setupJSDOM() {
-  // Enable `requestAnimationFrame` which Preact 10 uses for scheduling hooks.
+  // Enable `requestAnimationFrame` which Preact uses for scheduling hooks.
   const dom = new JSDOM('', { pretendToBeVisual: true });
   const g = global as any;
   g.Event = dom.window.Event;

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -382,7 +382,7 @@ function addInteractiveTests(render: typeof mount) {
     const err = new Error('Boom');
     child.simulateError(err);
     assert.equal(wrapper.text(), 'Something went wrong: $Boom');
-    // This assert fails because Preact 10 does not call `componentDidCatch`
+    // This assert fails because Preact does not call `componentDidCatch`
     // if `getDerivedStateFromError` is defined.
     // assert.equal(lastError, err);
 


### PR DESCRIPTION
Preact v10.x has long been the stable version of Preact, so we don't
need to specifically call out the version in various places.