### PR TITLE
Consistently use `import type`

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -3,7 +3,8 @@ import type {
   MountRendererProps,
   RSTNode,
 } from 'enzyme';
-import { VNode, h, createElement } from 'preact';
+import type { VNode } from 'preact';
+import { h, createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { render } from './compat.js';

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   ShallowRenderer as AbstractShallowRenderer,
   RSTNode,
   ShallowRenderOptions,
 } from 'enzyme';
-import { VNode } from 'preact';
+import type { VNode } from 'preact';
 
 import MountRenderer from './MountRenderer.js';
 import {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -3,7 +3,8 @@
  * Preact.
  */
 
-import { Component, Fragment, VNode } from 'preact';
+import type { Component, VNode } from 'preact';
+import { Fragment } from 'preact';
 
 import {
   getDOMNode,

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -1,4 +1,4 @@
-import { Component, VNode } from 'preact';
+import type { Component, VNode } from 'preact';
 
 /**
  * This module provides access to internal properties of Preact 10 VNodes,

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -8,7 +8,8 @@
  */
 
 import type { NodeType, RSTNode } from 'enzyme';
-import { Component, Fragment, VNode } from 'preact';
+import type { Component, VNode } from 'preact';
+import { Fragment } from 'preact';
 
 import { childElements } from './compat.js';
 import {

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -1,4 +1,5 @@
-import { ComponentFactory, Component, Fragment, VNode, options } from 'preact';
+import type { ComponentFactory, Component, VNode } from 'preact';
+import { Fragment, options } from 'preact';
 
 import { childElements } from './compat.js';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import type { RSTNode } from 'enzyme';
-import { VNode } from 'preact';
+import type { VNode } from 'preact';
 
 export function getType(obj: Object) {
   if (obj == null) {

--- a/test/Adapter_test.tsx
+++ b/test/Adapter_test.tsx
@@ -1,7 +1,7 @@
-import { VNode } from 'preact';
+import type { VNode } from 'preact';
 import * as preact from 'preact';
 import { assert } from 'chai';
-import { RSTNode } from 'enzyme';
+import type { RSTNode } from 'enzyme';
 
 import Adapter from '../src/Adapter.js';
 import MountRenderer from '../src/MountRenderer.js';

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { RSTNode } from 'enzyme';
+import type { RSTNode } from 'enzyme';
 import { Component } from 'preact';
 import * as preact from 'preact';
 import { useEffect, useLayoutEffect, useState } from 'preact/hooks';

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
-import { Component, Fragment, VNode } from 'preact';
+import type { VNode } from 'preact';
+import { Component, Fragment } from 'preact';
 import * as preact from 'preact';
-import { NodeType, RSTNode } from 'enzyme';
+import type { NodeType, RSTNode } from 'enzyme';
 
 import { getNode, rstNodeFromElement } from '../src/preact10-rst.js';
 import { getType } from '../src/util.js';

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -1,4 +1,5 @@
-import { Fragment, VNode, cloneElement } from 'preact';
+import type { VNode } from 'preact';
+import { Fragment, cloneElement } from 'preact';
 import { assert } from 'chai';
 import * as preact from 'preact';
 

--- a/test/util-test.tsx
+++ b/test/util-test.tsx
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { NodeType } from 'enzyme';
+import type { NodeType } from 'enzyme';
 
 import { getDisplayName } from '../src/util.js';
 


### PR DESCRIPTION
Small PR to consistently use `import type` across the codebase. I found this useful to understand what concrete parts of preact the adapter relies on and what parts of preact are just for types.