### PR TITLE
Add option to preserve Fragments when shallow rendering

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   root: true,
   rules: {
+    'no-inner-declarations': 'off',
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 'off',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The behavior turned on by this flag matches the behavior of the React 16
   enzyme adapter.
 
+- Add feature flag `preserveFragmentsInShallowRender` to more closely match
+  React 16 adapter's behavior of shallow rendering Fragments.
+
+  The handling of fragments differs between full and shallow rendering in the
+  React adapters. In "mount"/full renders, fragments do not appear in the RST
+  tree. In shallow renders they do.
+
+  In preactjs/enzyme-adapter-preact-pure#2, the decision was made to have this
+  adapter's shallow and mount renderers omit and skip over Fragments. Turning on
+  this option changes that behavior to match the React adapter's behavior and
+  preserve Fragments in shallow rendering.
+
+  It also implements the `isFragment` method on the Adapter, which gives control
+  of when to include Fragments in the output to Enzyme. In other words, this
+  flag preserves Fragments in the tree given to enzyme, which may then choose to
+  expose them or hide them in various APIs.
+
+  The behavior turned on by this flag is intended to more closely match the
+  behavior of the React 16 enzyme adapter.
+
 ## [4.0.1] - 2022-04-15
 
 - Added a partial fix for an incompatibility between Preact's JSX element type

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -28,6 +28,18 @@ export interface PreactAdapterOptions {
    * behavior of the React 16 enzyme adapter.
    */
   simulateEventsOnComponents?: boolean;
+
+  /**
+   * The handling of fragments differs between full and shallow rendering in the
+   * React adapters. In "mount"/full renders fragments do not appear in the RST
+   * tree. In shallow renders they do.
+   *
+   * In preactjs/enzyme-adapter-preact-pure#2, the decision was made to have
+   * this adapter's shallow and mount renderers omit and skip over Fragments.
+   * This option changes that behavior to match the React adapter's behavior and
+   * preserve Fragments in shallow rendering.
+   */
+  preserveFragmentsInShallowRender?: boolean;
 }
 
 export default class Adapter extends EnzymeAdapter {

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -31,7 +31,7 @@ export interface PreactAdapterOptions {
 
   /**
    * The handling of fragments differs between full and shallow rendering in the
-   * React adapters. In "mount"/full renders fragments do not appear in the RST
+   * React adapters. In "mount"/full renders, fragments do not appear in the RST
    * tree. In shallow renders they do.
    *
    * In preactjs/enzyme-adapter-preact-pure#2, the decision was made to have

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -7,7 +7,7 @@ import type {
 import enzyme from 'enzyme';
 import type { ReactElement } from 'react';
 import type { VNode } from 'preact';
-import { cloneElement, h } from 'preact';
+import { Fragment, cloneElement, h } from 'preact';
 
 import MountRenderer from './MountRenderer.js';
 import ShallowRenderer from './ShallowRenderer.js';
@@ -64,6 +64,18 @@ export default class Adapter extends EnzymeAdapter {
     // Work around a bug in Enzyme where `ShallowWrapper.getElements` calls
     // the `nodeToElement` method with undefined `this`.
     this.nodeToElement = this.nodeToElement.bind(this);
+
+    if (preactAdapterOptions.preserveFragmentsInShallowRender) {
+      // Implement isFragment when flag is on to better match React 16 adapter.
+      // The isFragment method is used by enzyme to skip over Fragments in some
+      // methods such as `children()` and `debug()`.
+      this.isFragment = (node: RSTNode): boolean => {
+        return (
+          (node?.type as any)?.originalType === Fragment ||
+          node?.type === Fragment
+        );
+      };
+    }
   }
 
   createRenderer(options: AdapterOptions & MountRendererProps) {

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -26,6 +26,12 @@ export interface Options extends MountRendererProps, PreactAdapterOptions {
    * If not specified, a detached element (not connected to the body) is used.
    */
   container?: HTMLElement;
+
+  /**
+   * The implementation of getNode to use for this renderer. Is customized by
+   * the shallow renderer
+   */
+  getNode?: typeof getNode;
 }
 
 function constructEvent(type: string, init: EventInit) {
@@ -46,7 +52,7 @@ export default class MountRenderer implements AbstractMountRenderer {
     installDebounceHook();
 
     this._container = options.container || document.createElement('div');
-    this._getNode = getNode;
+    this._getNode = options.getNode ?? getNode;
     this._options = options;
   }
 

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -11,11 +11,15 @@ import MountRenderer from './MountRenderer.js';
 import {
   withShallowRendering,
   shallowRenderVNodeTree,
-  patchShallowRoot,
+  withPatchedShallowRoot,
 } from './shallow-render-utils.js';
 import { childElements } from './compat.js';
 import { propFromEvent } from './util.js';
 import { getShallowNode } from './preact10-rst.js';
+import {
+  getChildren,
+  getLastVNodeRenderedIntoContainer,
+} from './preact10-internals.js';
 
 export type Options = PreactAdapterOptions;
 
@@ -34,10 +38,6 @@ export default class ShallowRenderer implements AbstractShallowRenderer {
   }
 
   render(el: VNode, context?: any, options?: ShallowRenderOptions) {
-    if (this._options.preserveFragmentsInShallowRender) {
-      patchShallowRoot(el);
-    }
-
     // Make all elements in the input tree, except for the root element, render
     // to a stub.
     childElements(el).forEach(el => {
@@ -48,7 +48,13 @@ export default class ShallowRenderer implements AbstractShallowRenderer {
 
     // Make any new elements rendered by the root element render to a stub.
     withShallowRendering(() => {
-      this._mountRenderer.render(el, context);
+      if (this._options.preserveFragmentsInShallowRender) {
+        withPatchedShallowRoot(el, el => {
+          this._mountRenderer.render(el, context);
+        });
+      } else {
+        this._mountRenderer.render(el, context);
+      }
 
       const rootNode = this._mountRenderer.getNode() as RSTNode;
       if (rootNode.type === 'host') {
@@ -88,7 +94,29 @@ export default class ShallowRenderer implements AbstractShallowRenderer {
   }
 
   getNode() {
-    return this._mountRenderer.getNode();
+    if (this._options.preserveFragmentsInShallowRender) {
+      // If a tests schedules an update on a component and then calls
+      // `wrapper.update()`, enzyme will end up invoking this method to get the
+      // updated nodes. MountRenderer calls `flushRenders` to process those
+      // updates in MountRenderer.getNode. Those rerenders need to happen with a
+      // patched root VNode that properly preserves Fragments so we'll patch the
+      // rootVNode here in case any rerenders are scheduled.
+
+      const rootFragment = getLastVNodeRenderedIntoContainer(
+        this._mountRenderer.container()
+      );
+
+      let rootVNode;
+      if (rootFragment) {
+        rootVNode = getChildren(rootFragment)[0];
+      }
+
+      return withPatchedShallowRoot(rootVNode, () =>
+        this._mountRenderer.getNode()
+      );
+    } else {
+      return this._mountRenderer.getNode();
+    }
   }
 
   batchedUpdates(fn: () => any) {

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -1,4 +1,8 @@
+import { Fragment } from 'preact';
 import type { Component, VNode } from 'preact';
+
+// This makes enzyme debug output easier to work with by giving Fragments a name that isn't minified
+Fragment.displayName = 'Fragment';
 
 /**
  * This module provides access to internal properties of Preact 10 VNodes,

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -44,7 +44,7 @@ function convertDOMProps(props: Props) {
  */
 function rstNodesFromChildren(
   nodes: (VNode | null)[] | null,
-  isShallow: boolean
+  preserveFragments: boolean
 ): RSTNodeTypes[] {
   if (!nodes) {
     return [];
@@ -57,14 +57,14 @@ function rstNodesFromChildren(
       // These are omitted from the rendered tree that Enzyme works with.
       return [];
     }
-    const rst = rstNodeFromVNode(node, isShallow);
+    const rst = rstNodeFromVNode(node, preserveFragments);
     return Array.isArray(rst) ? rst : [rst];
   });
 }
 
 function rstNodeFromVNode(
   node: VNode | null,
-  isShallow: boolean
+  preserveFragments: boolean
 ): RSTNodeTypes | RSTNodeTypes[] {
   if (node == null) {
     return null;
@@ -76,13 +76,13 @@ function rstNodeFromVNode(
     return String(node.props);
   }
 
-  if (!isShallow && node.type === Fragment) {
-    return rstNodesFromChildren(getChildren(node), isShallow);
+  if (!preserveFragments && node.type === Fragment) {
+    return rstNodesFromChildren(getChildren(node), preserveFragments);
   }
 
   const component = getComponent(node);
   if (component) {
-    return rstNodeFromComponent(node, component, isShallow);
+    return rstNodeFromComponent(node, component, preserveFragments);
   }
 
   if (!getDOMNode(node)) {
@@ -98,7 +98,7 @@ function rstNodeFromVNode(
     key: node.key || null,
     ref: node.ref || null,
     instance: getDOMNode(node),
-    rendered: rstNodesFromChildren(getChildren(node), isShallow),
+    rendered: rstNodesFromChildren(getChildren(node), preserveFragments),
   };
 }
 
@@ -152,13 +152,13 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
 function rstNodeFromComponent(
   vnode: VNode,
   component: Component,
-  isShallow: boolean
+  preserveFragments: boolean
 ): RSTNode {
   const nodeType = nodeTypeFromType(component.constructor);
 
   const rendered = rstNodesFromChildren(
     getLastRenderOutput(component),
-    isShallow
+    preserveFragments
   );
 
   // If this was a shallow-rendered component, set the RST node's type to the

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -148,6 +148,10 @@ function patchShallowRoot(root: VNode) {
     const rootType = root.type;
     const originalRender = rootType.prototype?.render ?? rootType;
     function EnzymePatchedRender(this: any, ...args: any[]) {
+      // TODO: It appears this needs to persist so external timers that fire
+      // outside of tests don't trigger deep rendering? This isn't a problem for
+      // the React shallow renderer cuz it doesn't invoke lifecycles that tend
+      // to trigger these problems
       let result;
       withShallowRendering(() => {
         result = originalRender.call(this, ...args);

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -164,6 +164,7 @@ export function patchShallowRoot(root: VNode) {
       rootType.prototype.render = EnzymePatchedRender;
     } else {
       root.type = EnzymePatchedRender;
+      (root.type as any).originalType = rootType;
       root.type.displayName = getDisplayName(rootType);
     }
 

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -165,7 +165,13 @@ export function patchShallowRoot(root: VNode) {
     } else {
       root.type = EnzymePatchedRender;
       (root.type as any).originalType = rootType;
+      // Give the wrapper a default display name
       root.type.displayName = getDisplayName(rootType);
+
+      // Copy over static properties like defaultProps and displayName
+      Object.keys(rootType).forEach(key => {
+        (root.type as any)[key] = (rootType as any)[key];
+      });
     }
 
     patchCache.add(root.type);

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -827,15 +827,17 @@ describe('integration tests', () => {
       addStaticTests(shallow);
       addInteractiveTests(shallow as any);
 
-      it('supports update and setState on Components that return Fragments with multiple children', () => {
+      it('supports update, setState, and setProps on Components that return Fragments with multiple children', () => {
         function Modal({ isOpen }: { isOpen: boolean }) {
           return <div>{isOpen ? 'open' : 'closed'}</div>;
         }
 
         class App extends preact.Component<
-          {},
+          { text?: string },
           { open: boolean; count: number }
         > {
+          static defaultProps = { text: 'Toggle' };
+
           constructor() {
             super();
             this.state = { open: false, count: 0 };
@@ -853,7 +855,7 @@ describe('integration tests', () => {
                   onClick={this.toggle}
                   data-count={this.state.count}
                 >
-                  Toggle
+                  {this.props.text}
                 </button>
                 <Modal isOpen={this.state.open} />
               </>
@@ -864,6 +866,7 @@ describe('integration tests', () => {
         const wrapper = shallow(<App />);
         const getInstance = () => wrapper.instance() as App;
 
+        assert.equal(wrapper.find('button').text(), 'Toggle');
         assert.equal(wrapper.find(Modal).props().isOpen, false);
 
         getInstance().toggle();
@@ -877,6 +880,9 @@ describe('integration tests', () => {
         wrapper.setState({ count: 10 });
         const buttonProps = wrapper.find('button').props() as any;
         assert.equal(buttonProps['data-count'], 10);
+
+        wrapper.setProps({ text: 'Open' });
+        assert.equal(wrapper.find('button').text(), 'Open');
       });
 
       it("matches React adapter's shallow render behavior for first(), children() and debug() with Fragments", () => {

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -137,7 +137,7 @@ describe('shallow-render-utils', () => {
   });
 
   describe('patchShallowRoot', () => {
-    it('class component static are preserved', () => {
+    it('class component static properties are preserved', () => {
       class C extends PreactComponent<{ name?: string }> {
         static defaultProps = { name: 'World' };
         render() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "jsx": "react",
     "jsxFactory": "preact.h",
+    "jsxFragmentFactory": "preact.Fragment",
     "module": "es2020",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
Add feature flag `preserveFragmentsInShallowRender` to more closely match React 16 adapter's behavior of shallow rendering Fragments.

The handling of fragments differs between full and shallow rendering in the React adapters. In "mount"/full renders, fragments do not appear in the RST tree. In shallow renders they do.

In preactjs/enzyme-adapter-preact-pure#2, the decision was made to have this adapter's shallow and mount renderers omit and skip over Fragments. Turning on this option changes that behavior to match the React adapter's behavior and preserve Fragments in shallow rendering.

It also implements the `isFragment` method on the Adapter, which gives control of when to include Fragments in the output to Enzyme. In other words, this flag preserves Fragments in the tree given to Enzyme, which may then choose to expose them or hide them in various APIs.

The behavior turned on by this flag is intended to more closely match the behavior of the React 16 enzyme adapter.

Check out the test [`supports update and setState on Components that return Fragments with multiple children`](https://github.com/preactjs/enzyme-adapter-preact-pure/pull/220/files#diff-26f422ed990715bf3e064cd9e6d8b98c2ffca550fd83532b8300db5e933e8a3bR830) for kind of test I need to support