### PR TITLE
Support more component return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support more return types (e.g. booleans, numbers, BigInts) from components
+
 - Add an option (`renderToString`) to allow passing in a custom string renderer
   to use for Enzyme's 'string' renderer instead of rendering into the DOM and
   reading the HTML output. It is expected that `renderToString` from

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare module 'preact' {
 declare module 'enzyme' {
   export type NodeType = 'function' | 'class' | 'host';
 
-  export type RSTNodeTypes = Exclude<ComponentChild, VNode> | RSTNode;
+  export type RSTNodeChild = Exclude<ComponentChild, VNode> | RSTNode;
 
   /**
    * A "React Standard Tree" node.
@@ -39,7 +39,7 @@ declare module 'enzyme' {
     instance: any;
 
     /** The result of the `render` function from this component. */
-    rendered: Array<RSTNodeTypes>;
+    rendered: Array<RSTNodeChild>;
   }
 
   /**
@@ -127,7 +127,7 @@ declare module 'enzyme' {
     createRenderer(options: AdapterOptions): Renderer;
     elementToNode(element: ReactElement): RSTNode;
     isValidElement(el: ReactElement): boolean;
-    nodeToElement(node: RSTNodeTypes): ReactElement | string;
+    nodeToElement(node: RSTNodeChild): ReactElement | string;
     nodeToHostNode(node: RSTNode): Node | null;
 
     // Optional methods.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-import { ComponentFactory, VNode } from 'preact';
+import type { ComponentChild, VNode } from 'preact';
 import 'enzyme';
-import { ReactElement, ReactInstance } from 'react';
+import type { ReactElement, ReactInstance } from 'react';
 
 // Extensions to the Preact types for compatibility with the Enzyme types.
 declare module 'preact' {
@@ -17,6 +17,8 @@ declare module 'preact' {
 // Extensions to the Enzyme types needed for writing an adapter.
 declare module 'enzyme' {
   export type NodeType = 'function' | 'class' | 'host';
+
+  export type RSTNodeTypes = Exclude<ComponentChild, VNode> | RSTNode;
 
   /**
    * A "React Standard Tree" node.
@@ -37,7 +39,7 @@ declare module 'enzyme' {
     instance: any;
 
     /** The result of the `render` function from this component. */
-    rendered: Array<RSTNode | string | null>;
+    rendered: Array<RSTNodeTypes>;
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ declare module 'enzyme' {
     createRenderer(options: AdapterOptions): Renderer;
     elementToNode(element: ReactElement): RSTNode;
     isValidElement(el: ReactElement): boolean;
-    nodeToElement(node: RSTNode): ReactElement | string;
+    nodeToElement(node: RSTNodeTypes): ReactElement | string;
     nodeToHostNode(node: RSTNode): Node | null;
 
     // Optional methods.

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -83,18 +83,6 @@ export default class Adapter extends EnzymeAdapter {
   }
 
   nodeToElement(node: RSTNodeChild): ReactElement | string {
-    if (node == null || typeof node === 'boolean') {
-      return '';
-    }
-
-    if (
-      typeof node === 'string' ||
-      typeof node === 'number' ||
-      typeof node === 'bigint'
-    ) {
-      return '' + node;
-    }
-
     if (!isRSTNode(node)) {
       return node as any;
     }

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -2,7 +2,7 @@ import type {
   AdapterOptions,
   MountRendererProps,
   RSTNode,
-  RSTNodeTypes,
+  RSTNodeChild,
   ShallowRendererProps,
 } from 'enzyme';
 import enzyme from 'enzyme';
@@ -82,7 +82,7 @@ export default class Adapter extends EnzymeAdapter {
     }
   }
 
-  nodeToElement(node: RSTNodeTypes): ReactElement | string {
+  nodeToElement(node: RSTNodeChild): ReactElement | string {
     if (node == null || typeof node === 'boolean') {
       return '';
     }
@@ -111,7 +111,7 @@ export default class Adapter extends EnzymeAdapter {
     return h(node.type as any, props, ...childElements) as ReactElement;
   }
 
-  nodeToHostNode(node: RSTNodeTypes): Node | null {
+  nodeToHostNode(node: RSTNodeChild): Node | null {
     return nodeToHostNode(node);
   }
 

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -7,9 +7,9 @@
  * The rendered result is converted to RST by traversing these vnode references.
  */
 
-import type { NodeType, RSTNode } from 'enzyme';
-import type { Component, VNode } from 'preact';
-import { Fragment } from 'preact';
+import type { NodeType, RSTNodeTypes, RSTNode } from 'enzyme';
+import type { Component, ComponentChild, VNode } from 'preact';
+import { isValidElement, Fragment } from 'preact';
 
 import { childElements } from './compat.js';
 import {
@@ -22,7 +22,6 @@ import {
 import { getRealType } from './shallow-render-utils.js';
 
 type Props = { [prop: string]: any };
-type RSTNodeTypes = RSTNode | string | null;
 
 function stripSpecialProps(props: Props) {
   const { children, key, ref, ...otherProps } = props;
@@ -112,8 +111,8 @@ function nodeTypeFromType(type: any): NodeType {
  * Convert a JSX element tree returned by Preact's `h` function into an RST
  * node.
  */
-export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
-  if (node == null || typeof node === 'string') {
+export function rstNodeFromElement(node: ComponentChild): RSTNodeTypes {
+  if (!isValidElement(node)) {
     return node;
   }
   const children = childElements(node).map(rstNodeFromElement);

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -7,7 +7,7 @@
  * The rendered result is converted to RST by traversing these vnode references.
  */
 
-import type { NodeType, RSTNodeTypes, RSTNode } from 'enzyme';
+import type { NodeType, RSTNodeChild, RSTNode } from 'enzyme';
 import type { Component, ComponentChild, VNode } from 'preact';
 import { isValidElement, Fragment } from 'preact';
 
@@ -41,7 +41,7 @@ function convertDOMProps(props: Props) {
 /**
  * Convert the rendered output of a vnode to RST nodes.
  */
-function rstNodesFromChildren(nodes: (VNode | null)[] | null): RSTNodeTypes[] {
+function rstNodesFromChildren(nodes: (VNode | null)[] | null): RSTNodeChild[] {
   if (!nodes) {
     return [];
   }
@@ -58,7 +58,7 @@ function rstNodesFromChildren(nodes: (VNode | null)[] | null): RSTNodeTypes[] {
   });
 }
 
-function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
+function rstNodeFromVNode(node: VNode | null): RSTNodeChild | RSTNodeChild[] {
   if (node == null) {
     return null;
   }
@@ -115,7 +115,7 @@ function nodeTypeFromType(type: any): NodeType {
  * Convert a JSX element tree returned by Preact's `h` function into an RST
  * node.
  */
-export function rstNodeFromElement(node: ComponentChild): RSTNodeTypes {
+export function rstNodeFromElement(node: ComponentChild): RSTNodeChild {
   if (!isValidElement(node)) {
     return node;
   }

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -65,7 +65,11 @@ function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
 
   // Preact 10 represents text nodes as VNodes with `node.type == null` and
   // `node.props` equal to the string content.
-  if (typeof node.props === 'string' || typeof node.props === 'number') {
+  if (
+    typeof node.props === 'string' ||
+    typeof node.props === 'number' ||
+    typeof node.props === 'bigint'
+  ) {
     return String(node.props);
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { RSTNode, RSTNodeTypes } from 'enzyme';
+import type { RSTNode, RSTNodeChild } from 'enzyme';
 import type { VNode } from 'preact';
 
 export function getType(obj: Object) {
@@ -57,7 +57,7 @@ export function toArray(obj: any) {
   return Array.isArray(obj) ? obj : [obj];
 }
 
-export function isRSTNode(node: RSTNodeTypes): node is RSTNode {
+export function isRSTNode(node: RSTNodeChild): node is RSTNode {
   return (
     node != null &&
     typeof node == 'object' &&
@@ -74,7 +74,7 @@ export function isRSTNode(node: RSTNodeTypes): node is RSTNode {
  * @returns The first host node in the children of the passed in node. Will
  * return the passed in node if it is a host node
  */
-export function nodeToHostNode(node: RSTNodeTypes): Node | null {
+export function nodeToHostNode(node: RSTNodeChild): Node | null {
   if (!isRSTNode(node)) {
     // Returning `null` here causes `wrapper.text()` to return nothing for a
     // wrapper around a `Text` node. That's not intuitive perhaps, but it

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { RSTNode } from 'enzyme';
+import type { RSTNode, RSTNodeTypes } from 'enzyme';
 import type { VNode } from 'preact';
 
 export function getType(obj: Object) {
@@ -57,13 +57,25 @@ export function toArray(obj: any) {
   return Array.isArray(obj) ? obj : [obj];
 }
 
+export function isRSTNode(node: RSTNodeTypes): node is RSTNode {
+  return (
+    node != null &&
+    typeof node == 'object' &&
+    'nodeType' in node &&
+    (node.nodeType === 'host' ||
+      node.nodeType === 'class' ||
+      node.nodeType === 'function') &&
+    'rendered' in node
+  );
+}
+
 /**
  * @param node The node to start searching for a host node
  * @returns The first host node in the children of the passed in node. Will
  * return the passed in node if it is a host node
  */
-export function nodeToHostNode(node: RSTNode | string | null): Node | null {
-  if (node == null || typeof node == 'string') {
+export function nodeToHostNode(node: RSTNodeTypes): Node | null {
+  if (!isRSTNode(node)) {
     // Returning `null` here causes `wrapper.text()` to return nothing for a
     // wrapper around a `Text` node. That's not intuitive perhaps, but it
     // matches the React adapters' behaviour.

--- a/test/Adapter_test.tsx
+++ b/test/Adapter_test.tsx
@@ -6,34 +6,7 @@ import Adapter from '../src/Adapter.js';
 import MountRenderer from '../src/MountRenderer.js';
 import ShallowRenderer from '../src/ShallowRenderer.js';
 import StringRenderer from '../src/StringRenderer.js';
-
-/**
- * Return a deep copy of a vnode, omitting internal fields that have a `__`
- * prefix.
- *
- * Stripping private fields is useful when comparing vnodes because the private
- * fields may differ even if the VNodes are logically the same value. For example
- * in some Preact versions VNodes include an ID counter field.
- */
-function stripInternalVNodeFields(obj: object | string) {
-  if (typeof obj == 'string') {
-    return obj;
-  }
-
-  const result = {} as Record<string, any>;
-  for (const [key, value] of Object.entries(obj)) {
-    if (!key.startsWith('__')) {
-      if (Array.isArray(value)) {
-        result[key] = value.map(v => stripInternalVNodeFields(v));
-      } else if (typeof value === 'object' && value !== null) {
-        result[key] = stripInternalVNodeFields(value);
-      } else {
-        result[key] = value;
-      }
-    }
-  }
-  return result as preact.VNode<any>;
-}
+import { stripInternalVNodeFields } from './shared.js';
 
 describe('Adapter', () => {
   it('adds `type` and `props` attributes to VNodes', () => {

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -73,6 +73,22 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
     assert.equal(wrapper.html(), '<button>Click me</button>');
   });
 
+  it('can return HTML content of mixed typed children', () => {
+    function Button({ label }: any) {
+      return (
+        <button>
+          {[null, undefined, true, false, 0n, ' ', label, ' ', 0]}
+        </button>
+      );
+    }
+
+    const wrapper = render(<Button label="Click me" />);
+    assert.equal(
+      wrapper.html(),
+      isStringRenderer ? '0 Click me 0' : '<button>0 Click me 0</button>'
+    );
+  });
+
   if (!isStringRenderer) {
     it('can find DOM nodes by class name', () => {
       function Widget() {

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import type { VNode } from 'preact';
 import { Component, Fragment } from 'preact';
 import * as preact from 'preact';
-import type { NodeType, RSTNode, RSTNodeTypes } from 'enzyme';
+import type { NodeType, RSTNode, RSTNodeChild } from 'enzyme';
 
 import { getNode, rstNodeFromElement } from '../src/preact10-rst.js';
 import { getType, isRSTNode } from '../src/util.js';
@@ -431,7 +431,7 @@ describe('preact10-rst', () => {
   });
 
   describe('rstNodeFromElement', () => {
-    function stripInstances(node: RSTNodeTypes) {
+    function stripInstances(node: RSTNodeChild) {
       if (!isRSTNode(node)) {
         return node;
       }

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -505,12 +505,10 @@ describe('preact10-rst', () => {
       },
       {
         description: 'element with mixed typed children',
-        element: (
-          <div>{[null, undefined, 'string', 1, true, false, 1n, {}]}</div>
-        ),
+        element: <div>{[null, undefined, 'string', 1, true, false, 1n]}</div>,
         expectedNode: hostNode({
           type: 'div',
-          rendered: [null, undefined, 'string', 1, true, false, 1n, {}],
+          rendered: [null, undefined, 'string', 1, true, false, 1n],
         }),
       },
     ].forEach(({ description, element, expectedNode }) => {

--- a/test/preact-rst-test.tsx
+++ b/test/preact-rst-test.tsx
@@ -2,10 +2,10 @@ import { assert } from 'chai';
 import type { VNode } from 'preact';
 import { Component, Fragment } from 'preact';
 import * as preact from 'preact';
-import type { NodeType, RSTNode } from 'enzyme';
+import type { NodeType, RSTNode, RSTNodeTypes } from 'enzyme';
 
 import { getNode, rstNodeFromElement } from '../src/preact10-rst.js';
-import { getType } from '../src/util.js';
+import { getType, isRSTNode } from '../src/util.js';
 import { render } from '../src/compat.js';
 
 function Child({ label }: any) {
@@ -119,7 +119,7 @@ function filterNode(node: RSTNode | null) {
 
   // Process rendered output.
   node.rendered.forEach(node => {
-    if (node && typeof node !== 'string' && node.nodeType) {
+    if (isRSTNode(node)) {
       filterNode(node);
     }
   });
@@ -431,8 +431,8 @@ describe('preact10-rst', () => {
   });
 
   describe('rstNodeFromElement', () => {
-    function stripInstances(node: RSTNode | string | null) {
-      if (node == null || typeof node === 'string') {
+    function stripInstances(node: RSTNodeTypes) {
+      if (!isRSTNode(node)) {
         return node;
       }
 
@@ -501,6 +501,16 @@ describe('preact10-rst', () => {
         expectedNode: hostNode({
           type: 'ul',
           rendered: [hostNode({ type: 'li', rendered: ['item'] })],
+        }),
+      },
+      {
+        description: 'element with mixed typed children',
+        element: (
+          <div>{[null, undefined, 'string', 1, true, false, 1n, {}]}</div>
+        ),
+        expectedNode: hostNode({
+          type: 'div',
+          rendered: [null, undefined, 'string', 1, true, false, 1n, {}],
         }),
       },
     ].forEach(({ description, element, expectedNode }) => {

--- a/test/shared.tsx
+++ b/test/shared.tsx
@@ -1,0 +1,27 @@
+/**
+ * Return a deep copy of a vnode, omitting internal fields that have a `__`
+ * prefix.
+ *
+ * Stripping private fields is useful when comparing vnodes because the private
+ * fields may differ even if the VNodes are logically the same value. For example
+ * in some Preact versions VNodes include an ID counter field.
+ */
+export function stripInternalVNodeFields(obj: object | string) {
+  if (typeof obj == 'string') {
+    return obj;
+  }
+
+  const result = {} as Record<string, any>;
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.startsWith('__')) {
+      if (Array.isArray(value)) {
+        result[key] = value.map(v => stripInternalVNodeFields(v));
+      } else if (typeof value === 'object' && value !== null) {
+        result[key] = stripInternalVNodeFields(value);
+      } else {
+        result[key] = value;
+      }
+    }
+  }
+  return result as preact.VNode<any>;
+}


### PR DESCRIPTION
Support more kinds of return types from components, using Preact's `ComponentChild` type as a guide.

Also fixes a bug where `ref` and `key` weren't restored on props in `nodeToElement`.