### PR TITLE
Add option to use `preact-render-to-string` for the StringRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a flag (`useRenderToString`) to change the string renderer to use
+  `preact-render-to-string` to render components instead of rendering into the
+  DOM and reading the HTML output. This change enables using the string renderer
+  in non-DOM environments and more closely matches the React adapter's behavior.
+
 - Add a feature flag (`simulateEventsOnComponents`) for supporting simulating
   events on Components
   [#211](https://github.com/preactjs/enzyme-adapter-preact-pure/pull/211)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add a flag (`useRenderToString`) to change the string renderer to use
-  `preact-render-to-string` to render components instead of rendering into the
-  DOM and reading the HTML output. This change enables using the string renderer
-  in non-DOM environments and more closely matches the React adapter's behavior.
+- Add an option (`renderToString`) to allow passing in a custom string renderer
+  to use for Enzyme's 'string' renderer instead of rendering into the DOM and
+  reading the HTML output. It is expected that `renderToString` from
+  `preact-render-to-string` is passed into this option. This change enables
+  using the string renderer in non-DOM environments and more closely matches the
+  React adapter's behavior.
 
 - Add a feature flag (`simulateEventsOnComponents`) for supporting simulating
   events on Components

--- a/examples/counter/test/setup.js
+++ b/examples/counter/test/setup.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { JSDOM } from 'jsdom';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-preact-pure';
@@ -8,11 +9,11 @@ const dom = new JSDOM('', {
   pretendToBeVisual: true,
 });
 
-global.Event = dom.window.Event;
-global.Node = dom.window.Node;
-global.window = dom.window;
-global.document = dom.window.document;
-global.requestAnimationFrame = dom.window.requestAnimationFrame;
+globalThis.Event = dom.window.Event;
+globalThis.Node = dom.window.Node;
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame;
 
 // Setup Enzyme
 configure({ adapter: new Adapter() });

--- a/examples/typescript/test/setup.ts
+++ b/examples/typescript/test/setup.ts
@@ -1,6 +1,7 @@
 // This `<reference ...>` directive is necessary to include the adapter's
 // extensions to types in the "preact" and "enzyme" packages.
 
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="enzyme-adapter-preact-pure"/>
 
 // @ts-ignore - JSDOM types are missing
@@ -16,15 +17,15 @@ const dom = new JSDOM('', {
 });
 
 // @ts-ignore
-global.Event = dom.window.Event;
+globalThis.Event = dom.window.Event;
 // @ts-ignore
-global.Node = dom.window.Node;
+globalThis.Node = dom.window.Node;
 // @ts-ignore
-global.window = dom.window;
+globalThis.window = dom.window;
 // @ts-ignore
-global.document = dom.window.document;
+globalThis.document = dom.window.document;
 // @ts-ignore
-global.requestAnimationFrame = dom.window.requestAnimationFrame;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame;
 
 // Setup Enzyme
 configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   },
   "peerDependencies": {
     "enzyme": "^3.11.0",
-    "preact": "^10.0.0",
-    "preact-render-to-string": "^5.2.6"
+    "preact": "^10.0.0"
   },
   "scripts": {
     "build": "tsc --build tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "preact": "^10.7.1",
+    "preact-render-to-string": "^5.2.6",
     "prettier": "2.7.1",
     "sinon": "^14.0.0",
     "source-map-support": "^0.5.12",
@@ -35,7 +36,8 @@
   },
   "peerDependencies": {
     "enzyme": "^3.11.0",
-    "preact": "^10.0.0"
+    "preact": "^10.0.0",
+    "preact-render-to-string": "^5.2.6"
   },
   "scripts": {
     "build": "tsc --build tsconfig.json",

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -30,10 +30,11 @@ export interface PreactAdapterOptions {
   simulateEventsOnComponents?: boolean;
 
   /**
-   * Flag to indicate to use preact-render-to-string for the 'string' enzyme
-   * renderer instead of mounting into a DOM and extracting the markup
+   * An option to provide a custom string renderer the 'string' enzyme renderer
+   * instead of mounting into a DOM and extracting the markup. It is expected
+   * that preact-render-to-string is passed here.
    */
-  useRenderToString?: boolean;
+  renderToString?: (el: VNode<any>, context: any) => string;
 }
 
 export default class Adapter extends EnzymeAdapter {

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -30,7 +30,7 @@ export interface PreactAdapterOptions {
   simulateEventsOnComponents?: boolean;
 
   /**
-   * An option to provide a custom string renderer the 'string' enzyme renderer
+   * An option to provide a custom string renderer for Enzyme's `string` rendering mode
    * instead of mounting into a DOM and extracting the markup. It is expected
    * that preact-render-to-string is passed here.
    */

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -28,6 +28,12 @@ export interface PreactAdapterOptions {
    * behavior of the React 16 enzyme adapter.
    */
   simulateEventsOnComponents?: boolean;
+
+  /**
+   * Flag to indicate to use preact-render-to-string for the 'string' enzyme
+   * renderer instead of mounting into a DOM and extracting the markup
+   */
+  useRenderToString?: boolean;
 }
 
 export default class Adapter extends EnzymeAdapter {
@@ -68,7 +74,7 @@ export default class Adapter extends EnzymeAdapter {
       case 'shallow':
         return new ShallowRenderer({ ...this.preactAdapterOptions });
       case 'string':
-        return new StringRenderer();
+        return new StringRenderer({ ...this.preactAdapterOptions });
       default:
         throw new Error(`"${options.mode}" rendering is not supported`);
     }

--- a/src/StringRenderer.ts
+++ b/src/StringRenderer.ts
@@ -1,16 +1,24 @@
 import type { Renderer, RSTNode } from 'enzyme';
 import type { ReactElement } from 'react';
 import { h, render } from 'preact';
+import renderToString from 'preact-render-to-string';
 
 import type { EventDetails } from './MountRenderer';
+import type { PreactAdapterOptions } from './Adapter';
 
 export default class StringRenderer implements Renderer {
+  constructor(private _options: PreactAdapterOptions) {}
+
   render(el: ReactElement, context?: any) {
-    const tempContainer = document.createElement('div');
-    render(el as any, tempContainer);
-    const html = tempContainer.innerHTML;
-    render(h('unmount-me', {}), tempContainer);
-    return html;
+    if (this._options.useRenderToString) {
+      return renderToString(el, context);
+    } else {
+      const tempContainer = document.createElement('div');
+      render(el as any, tempContainer);
+      const html = tempContainer.innerHTML;
+      render(h('unmount-me', {}), tempContainer);
+      return html;
+    }
   }
 
   simulateError(nodeHierarchy: RSTNode[], rootNode: RSTNode, error: any) {

--- a/src/StringRenderer.ts
+++ b/src/StringRenderer.ts
@@ -1,17 +1,20 @@
 import type { Renderer, RSTNode } from 'enzyme';
 import type { ReactElement } from 'react';
 import { h, render } from 'preact';
-import renderToString from 'preact-render-to-string';
 
 import type { EventDetails } from './MountRenderer';
 import type { PreactAdapterOptions } from './Adapter';
 
 export default class StringRenderer implements Renderer {
-  constructor(private _options: PreactAdapterOptions) {}
+  private _options: PreactAdapterOptions;
+
+  constructor(options: PreactAdapterOptions) {
+    this._options = options;
+  }
 
   render(el: ReactElement, context?: any) {
-    if (this._options.useRenderToString) {
-      return renderToString(el, context);
+    if (this._options.renderToString) {
+      return this._options.renderToString(el, context);
     } else {
       const tempContainer = document.createElement('div');
       render(el as any, tempContainer);

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -13,7 +13,7 @@ describe('MountRenderer', () => {
       const renderer = new MountRenderer();
       renderer.render(<div>Hello</div>);
 
-      const HTMLDivElement = (global as any).window.HTMLDivElement;
+      const HTMLDivElement = (globalThis as any).window.HTMLDivElement;
       assert.instanceOf(renderer.getNode()!.instance, HTMLDivElement);
     });
 

--- a/test/init.ts
+++ b/test/init.ts
@@ -1,20 +1,9 @@
-// @ts-expect-error - JSDOM types are missing
-import { JSDOM } from 'jsdom';
 import minimist from 'minimist';
+import { setupJSDOM } from './jsdom.js';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 // Setup DOM globals required by Preact rendering.
-function setupJSDOM() {
-  // Enable `requestAnimationFrame` which Preact uses for scheduling hooks.
-  const dom = new JSDOM('', { pretendToBeVisual: true });
-  const g = global as any;
-  g.Event = dom.window.Event;
-  g.Node = dom.window.Node;
-  g.window = dom.window;
-  g.document = dom.window.document;
-  g.requestAnimationFrame = dom.window.requestAnimationFrame;
-}
 setupJSDOM();
 
 // Support specifying a custom Preact library on the command line using

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -816,14 +816,14 @@ describe('integration tests', () => {
   describe('"string" rendering', () => {
     addStaticTests(renderToString as any);
 
-    describe('useRenderToString: true', () => {
+    describe('using preact-render-to-string (renderToString option)', () => {
       setAdapter(() => new Adapter({ renderToString: preactRenderToString }));
 
       // Ensure this flag works without a JSDOM environment so tear it down if
       // it exists before running these tests
       let reinitJSDOM = false;
       before(() => {
-        if (global.window) {
+        if (globalThis.window) {
           reinitJSDOM = true;
           teardownJSDOM();
         }

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -429,51 +429,12 @@ function setAdapter(createNewAdapter: () => Adapter) {
 
 describe('integration tests', () => {
   before(() => {
-    configure({ adapter: new Adapter() });
+    configure({ adapter: createDefaultAdapter() });
   });
 
   describe('"mount" rendering', () => {
     addStaticTests(mount);
     addInteractiveTests(mount);
-
-    it('supports simulating events on deep Components and elements', () => {
-      function FancyButton({ onClick, children }: any) {
-        return (
-          <button type="button" onClick={onClick}>
-            {children}
-          </button>
-        );
-      }
-
-      function FancierButton({ onClick, children }: any) {
-        return <FancyButton onClick={onClick}>{children}</FancyButton>;
-      }
-
-      function App() {
-        const [count, setCount] = useState(0);
-
-        return (
-          <div>
-            <div id="count">Count: {count}</div>
-            <FancierButton onClick={() => setCount(count + 1)}>
-              Increment
-            </FancierButton>
-          </div>
-        );
-      }
-
-      const wrapper = mount(<App />, {
-        // @ts-ignore This works but types don't say so
-        adapter: new Adapter({ simulateEventsOnComponents: true }),
-      });
-      assert.equal(wrapper.find('#count').text(), 'Count: 0');
-
-      wrapper.find(FancyButton).simulate('click');
-      assert.equal(wrapper.find('#count').text(), 'Count: 1');
-
-      wrapper.find('button').simulate('click');
-      assert.equal(wrapper.find('#count').text(), 'Count: 2');
-    });
 
     it('supports retrieving elements', () => {
       // Test workaround for bug where `Adapter.nodeToElement` is called
@@ -549,6 +510,46 @@ describe('integration tests', () => {
         output,
         '<Provider value={{...}}><Component><span>override</span></Component></Provider>'
       );
+    });
+
+    describe('simulateEventsOnComponents: true', () => {
+      setAdapter(() => new Adapter({ simulateEventsOnComponents: true }));
+
+      it('supports simulating events on deep Components and elements', () => {
+        function FancyButton({ onClick, children }: any) {
+          return (
+            <button type="button" onClick={onClick}>
+              {children}
+            </button>
+          );
+        }
+
+        function FancierButton({ onClick, children }: any) {
+          return <FancyButton onClick={onClick}>{children}</FancyButton>;
+        }
+
+        function App() {
+          const [count, setCount] = useState(0);
+
+          return (
+            <div>
+              <div id="count">Count: {count}</div>
+              <FancierButton onClick={() => setCount(count + 1)}>
+                Increment
+              </FancierButton>
+            </div>
+          );
+        }
+
+        const wrapper = mount(<App />);
+        assert.equal(wrapper.find('#count').text(), 'Count: 0');
+
+        wrapper.find(FancyButton).simulate('click');
+        assert.equal(wrapper.find('#count').text(), 'Count: 1');
+
+        wrapper.find('button').simulate('click');
+        assert.equal(wrapper.find('#count').text(), 'Count: 2');
+      });
     });
   });
 
@@ -772,35 +773,37 @@ describe('integration tests', () => {
       assert.equal(wrapper.text(), 'Example');
     });
 
-    it('supports simulating events on Components (simulateEventsOnComponents: true)', () => {
-      function FancyButton({ onClick, children }: any) {
-        return (
-          <button type="button" onClick={onClick}>
-            {children}
-          </button>
-        );
-      }
+    describe('simulateEventsOnComponents: true', () => {
+      setAdapter(() => new Adapter({ simulateEventsOnComponents: true }));
 
-      function App() {
-        const [count, setCount] = useState(0);
+      it('supports simulating events on Components', () => {
+        function FancyButton({ onClick, children }: any) {
+          return (
+            <button type="button" onClick={onClick}>
+              {children}
+            </button>
+          );
+        }
 
-        return (
-          <div>
-            <div id="count">Count: {count}</div>
-            <FancyButton onClick={() => setCount(count + 1)}>
-              Increment
-            </FancyButton>
-          </div>
-        );
-      }
+        function App() {
+          const [count, setCount] = useState(0);
 
-      const wrapper = shallow(<App />, {
-        adapter: new Adapter({ simulateEventsOnComponents: true }),
+          return (
+            <div>
+              <div id="count">Count: {count}</div>
+              <FancyButton onClick={() => setCount(count + 1)}>
+                Increment
+              </FancyButton>
+            </div>
+          );
+        }
+
+        const wrapper = shallow(<App />);
+        assert.equal(wrapper.find('#count').text(), 'Count: 0');
+
+        wrapper.find(FancyButton).simulate('click');
+        assert.equal(wrapper.find('#count').text(), 'Count: 1');
       });
-      assert.equal(wrapper.find('#count').text(), 'Count: 0');
-
-      wrapper.find(FancyButton).simulate('click');
-      assert.equal(wrapper.find('#count').text(), 'Count: 1');
     });
   });
 

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -416,6 +416,17 @@ function addInteractiveTests(render: typeof mount) {
   });
 }
 
+const createDefaultAdapter = () => new Adapter();
+function setAdapter(createNewAdapter: () => Adapter) {
+  beforeEach(() => {
+    configure({ adapter: createNewAdapter() });
+  });
+
+  afterEach(() => {
+    configure({ adapter: createDefaultAdapter() });
+  });
+}
+
 describe('integration tests', () => {
   before(() => {
     configure({ adapter: new Adapter() });
@@ -795,5 +806,10 @@ describe('integration tests', () => {
 
   describe('"string" rendering', () => {
     addStaticTests(renderToString as any);
+
+    describe('useRenderToString: true', () => {
+      setAdapter(() => new Adapter({ useRenderToString: true }));
+      addStaticTests(renderToString as any);
+    });
   });
 });

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -2,6 +2,7 @@ import type { CommonWrapper } from 'enzyme';
 import enzyme from 'enzyme';
 import { Component, Fragment, options } from 'preact';
 import * as preact from 'preact';
+import preactRenderToString from 'preact-render-to-string';
 import { useContext, useEffect, useState } from 'preact/hooks';
 import type { ReactElement } from 'react';
 
@@ -816,7 +817,7 @@ describe('integration tests', () => {
     addStaticTests(renderToString as any);
 
     describe('useRenderToString: true', () => {
-      setAdapter(() => new Adapter({ useRenderToString: true }));
+      setAdapter(() => new Adapter({ renderToString: preactRenderToString }));
 
       // Ensure this flag works without a JSDOM environment so tear it down if
       // it exists before running these tests

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -44,6 +44,8 @@ interface Wrapper extends CommonWrapper {
  * Register tests for static and interactive rendering modes.
  */
 function addStaticTests(render: (el: ReactElement) => Wrapper) {
+  const isStringRenderer = (render as any) === renderToString;
+
   it('renders a simple component', () => {
     function Button({ label }: any) {
       return <button>{label}</button>;
@@ -70,7 +72,7 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
     assert.equal(wrapper.html(), '<button>Click me</button>');
   });
 
-  if ((render as any) !== renderToString) {
+  if (!isStringRenderer) {
     it('can find DOM nodes by class name', () => {
       function Widget() {
         return <div class="widget">Test</div>;
@@ -113,7 +115,7 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
     });
   }
 
-  if ((render as any) !== renderToString) {
+  if (!isStringRenderer) {
     it('returns contents of fragments', () => {
       const el = (
         <div>
@@ -136,6 +138,9 @@ function addStaticTests(render: (el: ReactElement) => Wrapper) {
  * Register tests for interactive rendering modes (full + shallow rendering).
  */
 function addInteractiveTests(render: typeof mount) {
+  const isMount = (render as any) === mount;
+  const isShallow = (render as any) === shallow;
+
   it('supports finding child components', () => {
     function ListItem() {
       return <li>Test</li>;
@@ -186,9 +191,9 @@ function addInteractiveTests(render: typeof mount) {
 
     // nb. The node with `undefined` type is the Text node itself.
     let expected: Array<string | preact.AnyComponent | undefined>;
-    if (render === mount) {
+    if (isMount) {
       expected = [Widget, 'div', 'span', undefined];
-    } else if ((render as any) === shallow) {
+    } else if (isShallow) {
       // Shallow rendering omits the top-level component in the output.
       expected = ['div', 'span', undefined];
     } else {
@@ -372,8 +377,7 @@ function addInteractiveTests(render: typeof mount) {
     }
 
     const wrapper = render(<Parent />);
-    const expectedText =
-      (render as any) === shallow ? '<Child />' : 'Everything is working';
+    const expectedText = isShallow ? '<Child />' : 'Everything is working';
 
     // Initial render, we should see the original content.
     assert.equal(wrapper.text(), expectedText);

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -9,6 +9,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 
 import Adapter from '../src/Adapter.js';
+import { setupJSDOM, teardownJSDOM } from './jsdom.js';
 
 type TestContextValue = { myTestString: string };
 
@@ -812,6 +813,24 @@ describe('integration tests', () => {
 
     describe('useRenderToString: true', () => {
       setAdapter(() => new Adapter({ useRenderToString: true }));
+
+      // Ensure this flag works without a JSDOM environment so tear it down if
+      // it exists before running these tests
+      let reinitJSDOM = false;
+      before(() => {
+        if (global.window) {
+          reinitJSDOM = true;
+          teardownJSDOM();
+        }
+      });
+
+      after(() => {
+        if (reinitJSDOM) {
+          setupJSDOM();
+          reinitJSDOM = false;
+        }
+      });
+
       addStaticTests(renderToString as any);
     });
   });

--- a/test/jsdom.ts
+++ b/test/jsdom.ts
@@ -15,14 +15,14 @@ const jsdomGlobals: Record<string, (dom: JSDOM) => any> = {
 export function setupJSDOM() {
   // Enable `requestAnimationFrame` which Preact uses for scheduling hooks.
   const dom = new JSDOM('', { pretendToBeVisual: true });
-  const g = global as any;
+  const g = globalThis as any;
   for (const prop of Object.keys(jsdomGlobals)) {
     g[prop] = jsdomGlobals[prop](dom);
   }
 }
 
 export function teardownJSDOM() {
-  const g = global as any;
+  const g = globalThis as any;
   for (const prop in Object.keys(jsdomGlobals)) {
     delete g[prop];
   }

--- a/test/jsdom.ts
+++ b/test/jsdom.ts
@@ -1,0 +1,29 @@
+// @ts-expect-error - JSDOM types are missing
+import { JSDOM } from 'jsdom';
+
+type JSDOM = any;
+
+const jsdomGlobals: Record<string, (dom: JSDOM) => any> = {
+  Event: (jsdom: JSDOM) => jsdom.window.Event,
+  Node: (jsdom: JSDOM) => jsdom.window.Node,
+  window: (jsdom: JSDOM) => jsdom.window,
+  document: (jsdom: JSDOM) => jsdom.window.document,
+  requestAnimationFrame: (jsdom: JSDOM) => jsdom.window.requestAnimationFrame,
+};
+
+/** Setup DOM globals required by Preact rendering. */
+export function setupJSDOM() {
+  // Enable `requestAnimationFrame` which Preact uses for scheduling hooks.
+  const dom = new JSDOM('', { pretendToBeVisual: true });
+  const g = global as any;
+  for (const prop of Object.keys(jsdomGlobals)) {
+    g[prop] = jsdomGlobals[prop](dom);
+  }
+}
+
+export function teardownJSDOM() {
+  const g = global as any;
+  for (const prop in Object.keys(jsdomGlobals)) {
+    delete g[prop];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,6 +2641,13 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
+preact-render-to-string@^5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz#0ff0c86cd118d30affb825193f18e92bd59d0604"
+  integrity sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==
+  dependencies:
+    pretty-format "^3.8.0"
+
 preact@^10.7.1:
   version "10.11.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.2.tgz#e43f2a2f2985dedb426bb4c765b7bb037734f8a8"
@@ -2660,6 +2667,11 @@ prettier@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The React adapter's string renderer uses `renderToStaticMarkup` from `react-dom/server` allowing the string render to run in environments without a DOM. This PR adds an option to enable using `preact-render-to-string` for our string renderer to enable our string renderer to also run in environments without a DOM.

The tests for this renderer teardown the JSDOM environment set up for its tests to ensure the adapter with the new flag works in an environment without JSDOM.